### PR TITLE
Added raylib math functions to vector types

### DIFF
--- a/include/raylib/Vector2.hpp
+++ b/include/raylib/Vector2.hpp
@@ -5,11 +5,14 @@
 extern "C"{
 #endif
 #include "raylib.h"
+#include "raymath.h"
 #ifdef __cplusplus
 }
 #endif
 
 #include "utils.hpp"
+#include <cmath>
+#include <iostream>
 
 namespace raylib {
 	class Vector2 : public ::Vector2 {
@@ -38,6 +41,135 @@ namespace raylib {
             set(vector2);
             return *this;
         }
+		
+		Vector2 Add(const Vector2& vector2) {
+			return Vector2Add(*this, vector2);
+		}
+		
+		Vector2 operator+(const Vector2& vector2) {	
+			return Vector2Add(*this, vector2);
+		}
+		
+		Vector2 Subtract(const Vector2& vector2) {
+			return Vector2Subtract(*this, vector2);
+		}
+		
+		Vector2 operator-(const Vector2& vector2) {		
+			return Vector2Subtract(*this, vector2);
+		}
+		
+		Vector2 Negate() {
+			return Vector2Negate(*this);
+		}
+		
+		Vector2 operator-() {
+			return Vector2Negate(*this);
+		}
+		
+		Vector2 Multiply(const Vector2& vector2) {
+			return Vector2MultiplyV(*this, vector2);
+		}
+		
+		Vector2 operator*(const Vector2& vector2) {
+			return Vector2MultiplyV(*this, vector2);
+		}
+		
+		Vector2 Scale(const float scale) {
+			return Vector2Scale(*this, scale);
+		}
+		
+		Vector2 operator*(const float scale) {
+			return Vector2Scale(*this, scale);
+		}
+		
+		Vector2 Divide(const Vector2& vector2) {
+			return Vector2DivideV(*this, vector2);
+		}
+		
+		Vector2 operator/(const Vector2& vector2) {
+			return Vector2DivideV(*this, vector2);
+		}
+		
+		Vector2 Divide(const float div) {
+			return Vector2Divide(*this, div);
+		}
+		
+		Vector2 operator/(const float div) {		
+			return Vector2Divide(*this, div);
+		}
+		
+		Vector2& operator+=(const Vector2& vector2) {
+			set(Vector2Add(*this, vector2));
+		
+			return *this;
+		}
+		
+		Vector2& operator-=(const Vector2& vector2) {
+			set(Vector2Subtract(*this, vector2));
+			
+			return *this;
+		}
+
+		
+		Vector2& operator*=(const Vector2& vector2) {
+			set(Vector2MultiplyV(*this, vector2));
+			
+			return *this;
+		}
+		
+		Vector2& operator*=(const float scale) {
+			set(Vector2Scale(*this, scale));
+			
+			return *this;
+		}
+		
+		Vector2& operator/=(const Vector2& vector2) {
+			set(Vector2DivideV(*this, vector2));
+			
+			return *this;
+		}
+		
+		Vector2& operator/=(const float div) {
+			set(Vector2Divide(*this, div));
+			
+			return *this;
+		}
+		
+		float Length() {
+			return Vector2Length(*this);
+		}
+		
+		Vector2 Normalize() {
+			return Vector2Normalize(*this);	
+		}
+		
+		float DotProduct(const Vector2& vector2) {
+			return Vector2DotProduct(*this, vector2);
+		}
+		
+		float Angle(const Vector2& vector2) {
+			return Vector2Angle(*this, vector2);
+		}
+		
+		float Distance(const Vector2& vector2) {
+			return Vector2Distance(*this, vector2);
+		}
+		
+		Vector2 Lerp(const Vector2& vector2, const float amount) {
+			return Vector2Lerp(*this, vector2, amount);
+		}
+		
+		Vector2 Rotate(float degrees) {
+			return Vector2Rotate(*this, degrees);
+		}
+		
+		static Vector2 Zero() {
+			return Vector2Zero();
+		}
+		
+		static Vector2 One() {
+			return Vector2One();
+		}
 
 		inline Vector2& DrawPixel(::Color color) {
 			::DrawPixelV(*this, color);

--- a/include/raylib/Vector3.hpp
+++ b/include/raylib/Vector3.hpp
@@ -5,6 +5,7 @@
 extern "C"{
 #endif
 #include "raylib.h"
+#include "raymath.h"
 #ifdef __cplusplus
 }
 #endif
@@ -45,6 +46,163 @@ namespace raylib {
             set(vector3);
             return *this;
         }
+		
+		Vector3 Add(const Vector3& vector3) {
+			return Vector3Add(*this, vector3);
+		}
+		
+		Vector3 operator+(const Vector3& vector3) {	
+			return Vector3Add(*this, vector3);
+		}
+		
+		Vector3 Subtract(const Vector3& vector3) {
+			return Vector3Subtract(*this, vector3);
+		}
+		
+		Vector3 operator-(const Vector3& vector3) {		
+			return Vector3Subtract(*this, vector3);
+		}
+		
+		Vector3 Negate() {
+			return Vector3Negate(*this);
+		}
+		
+		Vector3 operator-() {
+			return Vector3Negate(*this);
+		}
+		
+		Vector3 Multiply(const Vector3& vector3) {
+			return Vector3Multiply(*this, vector3);
+		}
+		
+		Vector3 operator*(const Vector3& vector3) {
+			return Vector3Multiply(*this, vector3);
+		}
+		
+		Vector3 Scale(const float scale) {
+			return Vector3Scale(*this, scale);
+		}
+		
+		Vector3 operator*(const float scale) {
+			return Vector3Scale(*this, scale);
+		}
+		
+		Vector3 Divide(const Vector3& vector3) {
+			return Vector3DivideV(*this, vector3);
+		}
+		
+		Vector3 operator/(const Vector3& vector3) {
+			return Vector3DivideV(*this, vector3);
+		}
+		
+		Vector3 Divide(const float div) {
+			return Vector3Divide(*this, div);
+		}
+		
+		Vector3 operator/(const float div) {		
+			return Vector3Divide(*this, div);
+		}
+		
+		Vector3& operator+=(const Vector3& vector3) {
+			set(Vector3Add(*this, vector3));
+		
+			return *this;
+		}
+		
+		Vector3& operator-=(const Vector3& vector3) {
+			set(Vector3Subtract(*this, vector3));
+			
+			return *this;
+		}
+
+		
+		Vector3& operator*=(const Vector3& vector3) {
+			set(Vector3Multiply(*this, vector3));
+			
+			return *this;
+		}
+		
+		Vector3& operator*=(const float scale) {
+			set(Vector3Scale(*this, scale));
+			
+			return *this;
+		}
+		
+		Vector3& operator/=(const Vector3& vector3) {
+			set(Vector3DivideV(*this, vector3));
+			
+			return *this;
+		}
+		
+		Vector3& operator/=(const float div) {
+			set(Vector3Divide(*this, div));
+			
+			return *this;
+		}
+		
+		float Length() {
+			return Vector3Length(*this);
+		}
+		
+		Vector3 Normalize() {
+			return Vector3Normalize(*this);	
+		}
+		
+		float DotProduct(const Vector3& vector3) {
+			return Vector3DotProduct(*this, vector3);
+		}
+		
+		float Distance(const Vector3& vector3) {
+			return Vector3Distance(*this, vector3);
+		}
+		
+		Vector3 Lerp(const Vector3& vector3, const float amount) {
+			return Vector3Lerp(*this, vector3, amount);
+		}
+		
+		Vector3 CrossProduct(const Vector3& vector3) {
+			return Vector3CrossProduct(*this, vector3);
+		}
+		
+		Vector3 Perpendicular() {
+			return Vector3Perpendicular(*this);
+		}
+		
+		void OrthoNormalize(Vector3* vector3) {
+			return Vector3OrthoNormalize(this, vector3);
+		}
+		
+		Vector3 Transform(const Matrix& matrix) {
+			return Vector3Transform(*this, matrix);
+		}
+		
+		Vector3 RotateByQuaternion(Quaternion quaternion) {
+			return Vector3RotateByQuaternion(*this, quaternion);
+		}
+		
+		Vector3 Reflect(const Vector3& normal) {
+			return Vector3Reflect(*this, normal);
+		}
+		
+		Vector3 Min(const Vector3& vector3) {
+			return Vector3Min(*this, vector3);
+		}
+		
+		Vector3 Max(const Vector3& vector3) {
+			return Vector3Max(*this, vector3);
+		}
+		
+		Vector3 Barycenter(const Vector3& a, const Vector3& b, const Vector3& c) {
+			return Vector3Barycenter(*this, a, b, c);
+		}
+		
+		static Vector3 Zero() {
+			return Vector3Zero();
+		}
+		
+		static Vector3 One() {
+			return Vector3One();
+		}
 
 		inline Vector3& DrawLine3D(::Vector3 endPos, ::Color color) {
 			::DrawLine3D(*this, endPos, color);

--- a/include/raylib/Vector4.hpp
+++ b/include/raylib/Vector4.hpp
@@ -5,6 +5,7 @@
 extern "C"{
 #endif
 #include "raylib.h"
+#include "raymath.h"
 #ifdef __cplusplus
 }
 #endif
@@ -50,7 +51,90 @@ namespace raylib {
             set(vector4);
             return *this;
         }
-
+		
+		Vector4 Multiply(const Vector4& vector4) {
+			return QuaternionMultiply(*this, vector4);
+		}
+		
+		Vector4 operator*(const Vector4& vector4) {
+			return QuaternionMultiply(*this, vector4);
+		}
+		
+		Vector4 Lerp(const Vector4& vector4, float amount) {
+			return QuaternionLerp(*this, vector4, amount);
+		}
+		
+		Vector4 Nlerp(const Vector4& vector4, float amount) {
+			return QuaternionNlerp(*this, vector4, amount);
+		}
+		
+		Vector4 Slerp(const Vector4& vector4, float amount) {
+			return QuaternionSlerp(*this, vector4, amount);
+		}
+		
+		Matrix ToMatrix() {
+			return QuaternionToMatrix(*this);
+		}
+		
+		float Length() {
+			return QuaternionLength(*this);
+		}
+		
+		Vector4 Normalize() {
+			return QuaternionNormalize(*this);
+		}
+		
+		Vector4 Invert() {
+			return QuaternionInvert(*this);
+		}
+		
+		void ToAxisAngle(Vector3 *outAxis, float *outAngle) {
+			return QuaternionToAxisAngle(*this, outAxis, outAngle);
+		}
+		
+		std::pair<Vector3, float> ToAxisAngle() {
+			Vector3 outAxis;
+			float outAngle;
+			
+			QuaternionToAxisAngle(*this, &outAxis, &outAngle);
+			
+			std::pair<Vector3, float> out(outAxis, outAngle);
+			
+			return out;
+		}
+		
+		Vector3 ToEuler() {
+			return QuaternionToEuler(*this);
+		}
+		
+		Vector4 Transform(const Matrix& matrix) {
+			return QuaternionTransform(*this, matrix);
+		}
+		
+		static Vector4 Identity() {
+			return QuaternionIdentity();
+		}
+		
+		static Vector4 FromVector3ToVector3(const Vector3& from , const Vector3& to) {
+			return QuaternionFromVector3ToVector3(from , to);
+		}
+		
+		static Vector4 FromMatrix(const Matrix& matrix) {
+			return QuaternionFromMatrix(matrix);
+		}
+		
+		static Vector4 FromAxisAngle(const Vector3& axis, const float angle) {
+			return QuaternionFromAxisAngle(axis, angle);
+		}
+		
+		static Vector4 FromEuler(const float roll, const float pitch, const float yaw) {
+			return QuaternionFromEuler(roll, pitch, yaw);
+		}
+		
+		static Vector4 FromEuler(const Vector3& vector3) {
+			return QuaternionFromEuler(vector3.x, vector3.y, vector3.z);
+		}
+		
         inline Color ColorFromNormalized() {
         	return ::ColorFromNormalized(*this);
         }


### PR DESCRIPTION
Added all raylib vector math functions to the vector types as well as overloaded arithmetic operators where it made sense. Did not add Vector3ToFloat as c++ as far as I can tell does not trivially support returning created arrays.