### PR TITLE
fix audio device constructor call in examples

### DIFF
--- a/examples/audio/audio_music_stream.cpp
+++ b/examples/audio/audio_music_stream.cpp
@@ -20,7 +20,7 @@ int main(void)
 
     raylib::Window w(screenWidth, screenHeight, "raylib [audio] example - music playing (streaming)");
 
-    raylib::AudioDevice audio();              // Initialize audio device
+    raylib::AudioDevice audio;              // Initialize audio device
 
     raylib::Music music("resources/guitar_noodling.ogg");
 

--- a/examples/audio/audio_sound_loading.cpp
+++ b/examples/audio/audio_sound_loading.cpp
@@ -20,7 +20,7 @@ int main(void)
 
     raylib::Window w(screenWidth, screenHeight, "raylib [audio] example - sound loading and playing");
 
-    raylib::AudioDevice audiodevice();      // Initialize audio device
+    raylib::AudioDevice audiodevice;      // Initialize audio device
 
     raylib::Sound fxWav("resources/sound.wav");         // Load WAV audio file
     raylib::Sound fxOgg("resources/tanatana.ogg");      // Load OGG audio file


### PR DESCRIPTION
The audio examples were not working because the call to the `raylib::AudioDevice` constructor was wrong