### PR TITLE
Namespace raylib as raylibc

### DIFF
--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -34,7 +34,7 @@ namespace raylib {
 class Font : public ::Font {
  public:
     Font() {
-        set(::GetFontDefault());
+        set(raylibc::GetFontDefault());
     }
 
     Font(const std::string& fileName) {

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -34,20 +34,20 @@
 #include "./raylib-cpp-utils.hpp"
 
 namespace raylib {
-class Vector2 : public ::Vector2 {
+class Vector2 : public raylibc::Vector2 {
  public:
-    Vector2(::Vector2 vec) {
+    Vector2(raylibc::Vector2 vec) {
         set(vec);
     }
 
-    Vector2(float x, float y) : ::Vector2{x, y} {};
-    Vector2(float x) : ::Vector2{x, 0} {};
-    Vector2() : ::Vector2{0, 0} {};
+    Vector2(float x, float y) : raylibc::Vector2{x, y} {};
+    Vector2(float x) : raylibc::Vector2{x, 0} {};
+    Vector2() : raylibc::Vector2{0, 0} {};
 
     GETTERSETTER(float, X, x)
     GETTERSETTER(float, Y, y)
 
-    Vector2& operator=(const ::Vector2& vector2) {
+    Vector2& operator=(const raylibc::Vector2& vector2) {
         set(vector2);
         return *this;
     }
@@ -64,51 +64,51 @@ class Vector2 : public ::Vector2 {
 
 #ifndef RAYLIB_CPP_NO_MATH
     Vector2 Add(const Vector2& vector2) {
-        return Vector2Add(*this, vector2);
+        return raylibc::Vector2Add(*this, vector2);
     }
 
     Vector2 operator+(const Vector2& vector2) {
-        return Vector2Add(*this, vector2);
+        return raylibc::Vector2Add(*this, vector2);
     }
 
     Vector2 Subtract(const Vector2& vector2) {
-        return Vector2Subtract(*this, vector2);
+        return raylibc::Vector2Subtract(*this, vector2);
     }
 
     Vector2 operator-(const Vector2& vector2) {
-        return Vector2Subtract(*this, vector2);
+        return raylibc::Vector2Subtract(*this, vector2);
     }
 
     Vector2 Negate() {
-        return Vector2Negate(*this);
+        return raylibc::Vector2Negate(*this);
     }
 
     Vector2 operator-() {
-        return Vector2Negate(*this);
+        return raylibc::Vector2Negate(*this);
     }
 
     Vector2 Multiply(const Vector2& vector2) {
-        return Vector2Multiply(*this, vector2);
+        return raylibc::Vector2Multiply(*this, vector2);
     }
 
     Vector2 operator*(const Vector2& vector2) {
-        return Vector2Multiply(*this, vector2);
+        return raylibc::Vector2Multiply(*this, vector2);
     }
 
     Vector2 Scale(const float scale) {
-        return Vector2Scale(*this, scale);
+        return raylibc::Vector2Scale(*this, scale);
     }
 
     Vector2 operator*(const float scale) {
-        return Vector2Scale(*this, scale);
+        return raylibc::Vector2Scale(*this, scale);
     }
 
     Vector2 Divide(const Vector2& vector2) {
-        return Vector2Divide(*this, vector2);
+        return raylibc::Vector2Divide(*this, vector2);
     }
 
     Vector2 operator/(const Vector2& vector2) {
-        return Vector2Divide(*this, vector2);
+        return raylibc::Vector2Divide(*this, vector2);
     }
 
     Vector2& Divide(const float div) {
@@ -126,32 +126,32 @@ class Vector2 : public ::Vector2 {
     }
 
     Vector2& operator+=(const Vector2& vector2) {
-        set(Vector2Add(*this, vector2));
+        set(raylibc::Vector2Add(*this, vector2));
 
         return *this;
     }
 
     Vector2& operator-=(const Vector2& vector2) {
-        set(Vector2Subtract(*this, vector2));
+        set(raylibc::Vector2Subtract(*this, vector2));
 
         return *this;
     }
 
 
     Vector2& operator*=(const Vector2& vector2) {
-        set(Vector2Multiply(*this, vector2));
+        set(raylibc::Vector2Multiply(*this, vector2));
 
         return *this;
     }
 
     Vector2& operator*=(const float scale) {
-        set(Vector2Scale(*this, scale));
+        set(raylibc::Vector2Scale(*this, scale));
 
         return *this;
     }
 
     Vector2& operator/=(const Vector2& vector2) {
-        set(Vector2Divide(*this, vector2));
+        set(raylibc::Vector2Divide(*this, vector2));
 
         return *this;
     }
@@ -164,83 +164,83 @@ class Vector2 : public ::Vector2 {
     }
 
     float Length() const {
-        return Vector2Length(*this);
+        return raylibc::Vector2Length(*this);
     }
 
     Vector2 Normalize() {
-        return Vector2Normalize(*this);
+        return raylibc::Vector2Normalize(*this);
     }
 
     float DotProduct(const Vector2& vector2) {
-        return Vector2DotProduct(*this, vector2);
+        return raylibc::Vector2DotProduct(*this, vector2);
     }
 
     float Angle(const Vector2& vector2) {
-        return Vector2Angle(*this, vector2);
+        return raylibc::Vector2Angle(*this, vector2);
     }
 
     float Distance(const Vector2& vector2) {
-        return Vector2Distance(*this, vector2);
+        return raylibc::Vector2Distance(*this, vector2);
     }
 
     Vector2 Lerp(const Vector2& vector2, const float amount) {
-        return Vector2Lerp(*this, vector2, amount);
+        return raylibc::Vector2Lerp(*this, vector2, amount);
     }
 
     Vector2 Reflect(const Vector2& normal) {
-        return Vector2Reflect(*this, normal);
+        return raylibc::Vector2Reflect(*this, normal);
     }
 
     Vector2 Rotate(float degrees) {
-        return Vector2Rotate(*this, degrees);
+        return raylibc::Vector2Rotate(*this, degrees);
     }
 
     static Vector2 Zero() {
-        return Vector2Zero();
+        return raylibc::Vector2Zero();
     }
 
     static Vector2 One() {
-        return Vector2One();
+        return raylibc::Vector2One();
     }
 #endif
 
-    inline Vector2& DrawPixel(::Color color) {
-        ::DrawPixelV(*this, color);
+    inline Vector2& DrawPixel(raylibc::Color color) {
+        raylibc::DrawPixelV(*this, color);
         return *this;
     }
 
-    inline Vector2& DrawLine(::Vector2 endPos, ::Color color) {
-        ::DrawLineV(*this, endPos, color);
+    inline Vector2& DrawLine(raylibc::Vector2 endPos, raylibc::Color color) {
+        raylibc::DrawLineV(*this, endPos, color);
         return *this;
     }
 
-    inline Vector2& DrawLine(::Vector2 endPos, float thick, ::Color color) {
-        ::DrawLineEx(*this, endPos, thick, color);
+    inline Vector2& DrawLine(raylibc::Vector2 endPos, float thick, raylibc::Color color) {
+        raylibc::DrawLineEx(*this, endPos, thick, color);
         return *this;
     }
 
-    inline Vector2& DrawLineBezier(::Vector2 endPos, float thick, ::Color color) {
-        ::DrawLineBezier(*this, endPos, thick, color);
+    inline Vector2& DrawLineBezier(raylibc::Vector2 endPos, float thick, raylibc::Color color) {
+        raylibc::DrawLineBezier(*this, endPos, thick, color);
         return *this;
     }
 
-    inline Vector2& DrawCircle(float radius, ::Color color) {
-        ::DrawCircleV(*this, radius, color);
+    inline Vector2& DrawCircle(float radius, raylibc::Color color) {
+        raylibc::DrawCircleV(*this, radius, color);
         return *this;
     }
 
-    inline Vector2& DrawRectangle(::Vector2 size, ::Color color) {
-        ::DrawRectangleV(*this, size, color);
+    inline Vector2& DrawRectangle(raylibc::Vector2 size, raylibc::Color color) {
+        raylibc::DrawRectangleV(*this, size, color);
         return *this;
     }
 
-    inline Vector2& DrawPoly(int sides, float radius, float rotation, ::Color color) {
-        ::DrawPoly(*this, sides, radius, rotation, color);
+    inline Vector2& DrawPoly(int sides, float radius, float rotation, raylibc::Color color) {
+        raylibc::DrawPoly(*this, sides, radius, rotation, color);
         return *this;
     }
 
  protected:
-    inline void set(::Vector2 vec) {
+    inline void set(raylibc::Vector2 vec) {
         x = vec.x;
         y = vec.y;
     }

--- a/include/VrSimulator.hpp
+++ b/include/VrSimulator.hpp
@@ -35,7 +35,7 @@ class VrSimulator {
         Init();
     }
 
-    VrSimulator(::VrDeviceInfo info, ::Shader distortion) {
+    VrSimulator(raylibc::VrDeviceInfo info, raylibc::Shader distortion) {
         Init();
         Set(info, distortion);
     }
@@ -49,35 +49,35 @@ class VrSimulator {
     }
 
     inline bool IsReady() const {
-        return ::IsVrSimulatorReady();
+        return raylibc::IsVrSimulatorReady();
     }
 
     inline VrSimulator& Update(Camera *camera) {
-        ::UpdateVrTracking(camera);
+        raylibc::UpdateVrTracking(camera);
         return *this;
     }
 
-    inline VrSimulator& Set(::VrDeviceInfo info, ::Shader distortion) {
-        ::SetVrConfiguration(info, distortion);
+    inline VrSimulator& Set(raylibc::VrDeviceInfo info, raylibc::Shader distortion) {
+        raylibc::SetVrConfiguration(info, distortion);
         return *this;
     }
 
     inline VrSimulator& Toggle() {
-        ::ToggleVrMode();
+        raylibc::ToggleVrMode();
         return *this;
     }
 
     inline VrSimulator& Begin() {
-        ::BeginVrDrawing();
+        raylibc::BeginVrDrawing();
         return *this;
     }
 
     inline VrSimulator& End() {
-        ::EndVrDrawing();
+        raylibc::EndVrDrawing();
         return *this;
     }
     inline void Close() {
-        ::CloseVrSimulator();
+        raylibc::CloseVrSimulator();
     }
 };
 }  // namespace raylib

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -31,9 +31,9 @@
 #include "./raylib-cpp-utils.hpp"
 
 namespace raylib {
-class Wave : public ::Wave {
+class Wave : public raylibc::Wave {
  public:
-    Wave(::Wave wave) {
+    Wave(raylibc::Wave wave) {
         set(wave);
     }
 
@@ -49,11 +49,11 @@ class Wave : public ::Wave {
     }
 
     Wave(const std::string& fileName) {
-        set(LoadWave(fileName.c_str()));
+        set(raylibc::LoadWave(fileName.c_str()));
     }
 
     Wave(const std::string& fileType, const unsigned char *fileData, int dataSize) {
-        set(LoadWaveFromMemory(fileType.c_str(), fileData, dataSize));
+        set(raylibc::LoadWaveFromMemory(fileType.c_str(), fileData, dataSize));
     }
 
     ~Wave() {
@@ -66,7 +66,7 @@ class Wave : public ::Wave {
     GETTERSETTER(unsigned int, Channels, channels)
     GETTERSETTER(void *, Data, data)
 
-    Wave& operator=(const ::Wave& wave) {
+    Wave& operator=(const raylibc::Wave& wave) {
         set(wave);
         return *this;
     }
@@ -77,38 +77,38 @@ class Wave : public ::Wave {
     }
 
     inline Wave& Format(int SampleRate = 0, int SampleSize = 0, int Channels = 2) {
-        ::WaveFormat(this, SampleRate, SampleSize, Channels);
+        raylibc::WaveFormat(this, SampleRate, SampleSize, Channels);
         return *this;
     }
 
     inline Wave Copy() {
-        return ::WaveCopy(*this);
+        return raylibc::WaveCopy(*this);
     }
 
     inline Wave& Crop(int initSample, int finalSample) {
-        ::WaveCrop(this, initSample, finalSample);
+        raylibc::WaveCrop(this, initSample, finalSample);
         return *this;
     }
 
     inline Wave& Export(const std::string& fileName) {
-        ::ExportWave(*this, fileName.c_str());
+        raylibc::ExportWave(*this, fileName.c_str());
         return *this;
     }
 
     inline Wave& ExportAsCode(const std::string& fileName) {
-        ::ExportWaveAsCode(*this, fileName.c_str());
+        raylibc::ExportWaveAsCode(*this, fileName.c_str());
         return *this;
     }
 
     void Unload() {
         if (data != NULL) {
-            ::UnloadWave(*this);
+            raylibc::UnloadWave(*this);
             data = NULL;
         }
     }
 
     inline Sound LoadSound() {
-        return ::LoadSoundFromWave(*this);
+        return raylibc::LoadSoundFromWave(*this);
     }
 
     inline operator Sound() {
@@ -116,11 +116,11 @@ class Wave : public ::Wave {
     }
 
     inline float* GetData() {
-        return ::GetWaveData(*this);
+        return raylibc::GetWaveData(*this);
     }
 
  protected:
-    inline void set(::Wave wave) {
+    inline void set(raylibc::Wave wave) {
         sampleCount = wave.sampleCount;
         sampleRate = wave.sampleRate;
         sampleSize = wave.sampleSize;

--- a/include/raylib.hpp
+++ b/include/raylib.hpp
@@ -25,6 +25,7 @@
 #ifndef RAYLIB_CPP_INCLUDE_RAYLIB_HPP_
 #define RAYLIB_CPP_INCLUDE_RAYLIB_HPP_
 
+namespace raylibc {
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,5 +33,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+}
 
 #endif  // RAYLIB_CPP_INCLUDE_RAYLIB_HPP_

--- a/include/raymath.hpp
+++ b/include/raymath.hpp
@@ -25,6 +25,7 @@
 #ifndef RAYLIB_CPP_INCLUDE_RAYMATH_HPP_
 #define RAYLIB_CPP_INCLUDE_RAYMATH_HPP_
 
+namespace raylibc {
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -34,5 +35,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+}
 
 #endif  // RAYLIB_CPP_INCLUDE_RAYMATH_HPP_


### PR DESCRIPTION
I'm unclear on the implications of this.... #45

If we bring all of raylib.h into the `raylib` namespace, there are name conflicts on the classes like `Vector2`. Thought using `raylibc` would be a good substitute, but I'm still unclear on how this would affect different situations. Including a C library inside a C++ namespace feels wrong.