### PR TITLE
Add a link to the raylib-cpp-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ raylib::Vector2 newDirection = direction.Rotate(30);
 The [projects directory](projects) includes some starter templates...
 
 - [CMake template](projects/CMake)
+- [Make template](projects/Make)
 
 If there's a project template you would like to see added, feel free to [make an issue](https://github.com/RobLoach/raylib-cpp/issues) and we can add it in.
 

--- a/projects/Make/README.md
+++ b/projects/Make/README.md
@@ -13,7 +13,7 @@ The [Raylib C++ Starter Kit](https://github.com/CapsCollective/raylib-cpp-starte
     ```
     cd raylib-cpp-starter
 
-    # Linux
+    # Linux & macOS
     make setup
     make
 

--- a/projects/Make/README.md
+++ b/projects/Make/README.md
@@ -1,0 +1,31 @@
+# raylib-cpp Make Example Project
+
+The [Raylib C++ Starter Kit](https://github.com/CapsCollective/raylib-cpp-starter), put together by [CapsCollective](https://caps-collective.itch.io), uses [`make`](https://www.gnu.org/software/make/) to compile a raylib-cpp starter project.
+
+## Build
+
+1. Check out the repository
+    ```
+    git clone https://github.com/CapsCollective/raylib-cpp-starter.git
+    ```
+
+2. Build the project
+    ```
+    cd raylib-cpp-starter
+
+    # Linux
+    make setup
+    make
+
+    # Windows
+    mingw32-make setup
+    mingw32-make
+    ```
+
+## Documentation
+
+See the [Raylib C++ Starter project](https://github.com/CapsCollective/raylib-cpp-starter) for more documentation.
+
+## Credits
+
+- [CapsCollective](https://caps-collective.itch.io)


### PR DESCRIPTION
This adds a link to the raylib-cpp-starter for a working Make template by @J-Mo63! Have any thoughts, J-Mo?

Fixes #89, fixes #87