### PR TITLE
raylib::Window::GetSize() is now a const method

### DIFF
--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -266,7 +266,7 @@ class Window {
     /**
      * Get the screen's width and height.
      */
-    inline Vector2 GetSize() {
+    inline Vector2 GetSize() const {
         return {static_cast<float>(GetWidth()), static_cast<float>(GetHeight())};
     }
 


### PR DESCRIPTION
This fixes issue #176.