### PR TITLE
Fix move operators

### DIFF
--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -60,7 +60,7 @@ class AudioStream : public ::AudioStream {
 
     AudioStream& operator=(const AudioStream&) = delete;
 
-    AudioStream& operator=(AudioStream&& other) {
+    AudioStream& operator=(AudioStream&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -122,7 +122,7 @@ class Font : public ::Font {
 
     Font& operator=(const Font&) = delete;
 
-    Font& operator=(Font&& other) {
+    Font& operator=(Font&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -203,7 +203,7 @@ class Image : public ::Image {
         return *this;
     }
 
-    Image& operator=(Image&& other) {
+    Image& operator=(Image&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -59,7 +59,7 @@ class Material : public ::Material {
 
     Material& operator=(const Material&) = delete;
 
-    Material& operator=(Material&& other) {
+    Material& operator=(Material&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -60,7 +60,7 @@ class Material : public ::Material {
     Material& operator=(const Material&) = delete;
 
     Material& operator=(Material&& other) {
-        if (this != &other) {
+        if (this == &other) {
             return *this;
         }
 

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -161,7 +161,7 @@ class Mesh : public ::Mesh {
 
     Mesh& operator=(const Mesh&) = delete;
 
-    Mesh& operator=(Mesh&& other) {
+    Mesh& operator=(Mesh&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -162,7 +162,7 @@ class Mesh : public ::Mesh {
     Mesh& operator=(const Mesh&) = delete;
 
     Mesh& operator=(Mesh&& other) {
-        if (this != &other) {
+        if (this == &other) {
             return *this;
         }
 

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -65,7 +65,7 @@ class Model : public ::Model {
 
     Model& operator=(const Model&) = delete;
 
-    Model& operator=(Model&& other) {
+    Model& operator=(Model&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -66,7 +66,7 @@ class Model : public ::Model {
     Model& operator=(const Model&) = delete;
 
     Model& operator=(Model&& other) {
-        if (this != &other) {
+        if (this == &other) {
             return *this;
         }
 

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -58,7 +58,7 @@ class ModelAnimation : public ::ModelAnimation {
 
     ModelAnimation& operator=(const ModelAnimation&) = delete;
 
-    ModelAnimation& operator=(ModelAnimation&& other) {
+    ModelAnimation& operator=(ModelAnimation&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -59,7 +59,7 @@ class ModelAnimation : public ::ModelAnimation {
     ModelAnimation& operator=(const ModelAnimation&) = delete;
 
     ModelAnimation& operator=(ModelAnimation&& other) {
-        if (this != &other) {
+        if (this == &other) {
             return *this;
         }
 

--- a/include/Music.hpp
+++ b/include/Music.hpp
@@ -82,7 +82,7 @@ class Music : public ::Music {
 
     Music& operator=(const Music&) = delete;
 
-    Music& operator=(Music&& other) {
+    Music& operator=(Music&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -51,7 +51,7 @@ class RenderTexture : public ::RenderTexture {
 
     RenderTexture& operator=(const RenderTexture&) = delete;
 
-    RenderTexture& operator=(RenderTexture&& other) {
+    RenderTexture& operator=(RenderTexture&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -64,7 +64,7 @@ class Shader : public ::Shader {
 
     Shader& operator=(const Shader&) = delete;
 
-    Shader& operator=(Shader&& other) {
+    Shader& operator=(Shader&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -65,7 +65,7 @@ class Shader : public ::Shader {
     Shader& operator=(const Shader&) = delete;
 
     Shader& operator=(Shader&& other) {
-        if (this != &other) {
+        if (this == &other) {
             return *this;
         }
 

--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -66,7 +66,7 @@ class Sound : public ::Sound {
     GETTERSETTER(unsigned int, FrameCount, frameCount)
     GETTERSETTER(::AudioStream, Stream, stream)
 
-    Sound& operator=(Sound&& other) {
+    Sound& operator=(Sound&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -97,7 +97,7 @@ class Texture : public ::Texture {
 
     Texture& operator=(const Texture&) = delete;
 
-    Texture& operator=(Texture&& other) {
+    Texture& operator=(Texture&& other) noexcept {
         if (this == &other) {
             return *this;
         }

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -87,7 +87,7 @@ class Wave : public ::Wave {
         return *this;
     }
 
-    Wave& operator=(Wave&& other) {
+    Wave& operator=(Wave&& other) noexcept {
         if (this != &other) {
             return *this;
         }

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -77,7 +77,7 @@ class Wave : public ::Wave {
     }
 
     Wave& operator=(const Wave& other) {
-        if (&other != this) {
+        if (this == &other) {
             return *this;
         }
 


### PR DESCRIPTION
This PR addresses the following:

- Some move operators had the following check:
  ```cpp
  if (this != &other) return *this;
  ```
  which is obviously a typo since you want to return `this` if it's the same, not if it's different.

- (not really important) while I was there I also added `noexcept` to allow move operators to be used by the STL containers. See [here](https://clang.llvm.org/extra/clang-tidy/checks/performance-noexcept-move-constructor.html) for an explanation why

I highly recommend you try `clangd` and/or `clang-tidy`: I see in `v4.0.0` you additionally have some missing returns in move ops, `clangd` would have easily caught it.