### PR TITLE
Remove inline for set() calls

### DIFF
--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -53,6 +53,8 @@ class AudioStream : public ::AudioStream {
     GETTERSETTER(unsigned int, SampleSize, sampleSize)
     GETTERSETTER(unsigned int, Channels, channels)
 
+    /**
+     *
     AudioStream& operator=(const ::AudioStream& stream) {
         set(stream);
         return *this;
@@ -178,7 +180,7 @@ class AudioStream : public ::AudioStream {
     }
 
  private:
-    inline void set(const ::AudioStream& stream) {
+    void set(const ::AudioStream& stream) {
         buffer = stream.buffer;
         sampleRate = stream.sampleRate;
         sampleSize = stream.sampleSize;

--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -53,8 +53,6 @@ class AudioStream : public ::AudioStream {
     GETTERSETTER(unsigned int, SampleSize, sampleSize)
     GETTERSETTER(unsigned int, Channels, channels)
 
-    /**
-     *
     AudioStream& operator=(const ::AudioStream& stream) {
         set(stream);
         return *this;

--- a/include/BoundingBox.hpp
+++ b/include/BoundingBox.hpp
@@ -69,7 +69,7 @@ class BoundingBox : public ::BoundingBox {
     }
 
  private:
-    inline void set(const ::BoundingBox& box) {
+    void set(const ::BoundingBox& box) {
         min = box.min;
         max = box.max;
     }

--- a/include/Camera2D.hpp
+++ b/include/Camera2D.hpp
@@ -61,7 +61,7 @@ class Camera2D : public ::Camera2D {
     }
 
  private:
-    inline void set(const ::Camera2D& camera) {
+    void set(const ::Camera2D& camera) {
         offset = camera.offset;
         target = camera.target;
         rotation = camera.rotation;

--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -149,7 +149,7 @@ class Camera3D : public ::Camera3D {
     }
 
  private:
-    inline void set(const ::Camera3D& camera) {
+    void set(const ::Camera3D& camera) {
         position = camera.position;
         target = camera.target;
         up = camera.up;

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -245,7 +245,7 @@ class Color : public ::Color {
     inline static Color RayWhite() { return RAYWHITE; }
 
  private:
-    inline void set(const ::Color& color) {
+    void set(const ::Color& color) {
         r = color.r;
         g = color.g;
         b = color.b;

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -719,7 +719,7 @@ class Image : public ::Image {
     }
 
  private:
-    inline void set(const ::Image& image) {
+    void set(const ::Image& image) {
         data = image.data;
         width = image.width;
         height = image.height;

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -108,7 +108,7 @@ class Material : public ::Material {
     }
 
  private:
-    inline void set(const ::Material& material) {
+    void set(const ::Material& material) {
         shader = material.shader;
         maps = material.maps;
         params[0] = material.params[0];

--- a/include/Matrix.hpp
+++ b/include/Matrix.hpp
@@ -191,7 +191,7 @@ class Matrix : public ::Matrix {
 #endif
 
  private:
-    inline void set(const ::Matrix& mat) {
+    void set(const ::Matrix& mat) {
         m0 = mat.m0;
         m1 = mat.m1;
         m2 = mat.m2;

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -283,7 +283,7 @@ class Mesh : public ::Mesh {
     }
 
  private:
-    inline void set(const ::Mesh& mesh) {
+    void set(const ::Mesh& mesh) {
         vertexCount = mesh.vertexCount;
         triangleCount = mesh.triangleCount;
         vertices = mesh.vertices;

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -221,7 +221,7 @@ class Model : public ::Model {
     }
 
  private:
-    inline void set(const ::Model& model) {
+    void set(const ::Model& model) {
         transform = model.transform;
 
         meshCount = model.meshCount;

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -97,7 +97,7 @@ class ModelAnimation : public ::ModelAnimation {
     }
 
  private:
-    inline void set(const ::ModelAnimation& model) {
+    void set(const ::ModelAnimation& model) {
         boneCount = model.boneCount;
         bones = model.bones;
         frameCount = model.frameCount;

--- a/include/Music.hpp
+++ b/include/Music.hpp
@@ -217,7 +217,7 @@ class Music : public ::Music {
     }
 
  private:
-    inline void set(const ::Music& music) {
+    void set(const ::Music& music) {
         ctxType = music.ctxType;
         ctxData = music.ctxData;
         looping = music.looping;

--- a/include/Ray.hpp
+++ b/include/Ray.hpp
@@ -89,7 +89,7 @@ class Ray : public ::Ray {
     }
 
  private:
-    void set(const ::Ray& ray) {
+    inline void set(const ::Ray& ray) {
         position = ray.position;
         direction = ray.direction;
     }

--- a/include/Ray.hpp
+++ b/include/Ray.hpp
@@ -89,7 +89,7 @@ class Ray : public ::Ray {
     }
 
  private:
-    inline void set(const ::Ray& ray) {
+    void set(const ::Ray& ray) {
         position = ray.position;
         direction = ray.direction;
     }

--- a/include/RayCollision.hpp
+++ b/include/RayCollision.hpp
@@ -51,7 +51,7 @@ class RayCollision : public ::RayCollision {
     GETTERSETTER(::Vector3, Normal, normal)
 
  private:
-    inline void set(const ::RayCollision& ray) {
+    void set(const ::RayCollision& ray) {
         hit = ray.hit;
         distance = ray.distance;
         point = ray.point;

--- a/include/Rectangle.hpp
+++ b/include/Rectangle.hpp
@@ -159,7 +159,7 @@ class Rectangle : public ::Rectangle {
     }
 
  private:
-    inline void set(const ::Rectangle& rect) {
+    void set(const ::Rectangle& rect) {
         x = rect.x;
         y = rect.y;
         width = rect.width;

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -106,7 +106,7 @@ class RenderTexture : public ::RenderTexture {
     }
 
  private:
-    inline void set(const ::RenderTexture& renderTexture) {
+    void set(const ::RenderTexture& renderTexture) {
         id = renderTexture.id;
         texture = renderTexture.texture;
         depth = renderTexture.depth;

--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -170,7 +170,7 @@ class Shader : public ::Shader {
     }
 
  private:
-    inline void set(const ::Shader& shader) {
+    void set(const ::Shader& shader) {
         id = shader.id;
         locs = shader.locs;
     }

--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -202,7 +202,7 @@ class Sound : public ::Sound {
     }
 
  private:
-    inline void set(const ::Sound& sound) {
+    void set(const ::Sound& sound) {
         frameCount = sound.frameCount;
         stream = sound.stream;
     }

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -307,7 +307,7 @@ class Texture : public ::Texture {
     }
 
  private:
-    inline void set(const ::Texture& texture) {
+    void set(const ::Texture& texture) {
         id = texture.id;
         width = texture.width;
         height = texture.height;

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -316,7 +316,7 @@ class Vector2 : public ::Vector2 {
     }
 
  private:
-    inline void set(const ::Vector2& vec) {
+    void set(const ::Vector2& vec) {
         x = vec.x;
         y = vec.y;
     }

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -299,7 +299,7 @@ class Vector3 : public ::Vector3 {
     }
 
  private:
-    inline void set(const ::Vector3& vec) {
+    void set(const ::Vector3& vec) {
         x = vec.x;
         y = vec.y;
         z = vec.z;

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -154,7 +154,7 @@ class Vector4 : public ::Vector4 {
     }
 
  private:
-    inline void set(const ::Vector4& vec4) {
+    void set(const ::Vector4& vec4) {
         x = vec4.x;
         y = vec4.y;
         z = vec4.z;

--- a/include/VrStereoConfig.hpp
+++ b/include/VrStereoConfig.hpp
@@ -52,7 +52,7 @@ class VrStereoConfig : public ::VrStereoConfig  {
     }
 
  private:
-    inline void set(const ::VrStereoConfig& config) {
+    void set(const ::VrStereoConfig& config) {
         projection[0] = config.projection[0];
         viewOffset[1] = config.viewOffset[1];
         projection[0] = config.projection[0];

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -211,7 +211,7 @@ class Wave : public ::Wave {
     }
 
  private:
-    inline void set(const ::Wave& wave) {
+    void set(const ::Wave& wave) {
         frameCount = wave.frameCount;
         sampleRate = wave.sampleRate;
         sampleSize = wave.sampleSize;


### PR DESCRIPTION
Considering `set()` can be a few different lines, it could be worth removing the `inline` from them.