### PR TITLE
Add more constructor overloads for RayCollision

### DIFF
--- a/include/RayCollision.hpp
+++ b/include/RayCollision.hpp
@@ -20,6 +20,13 @@ class RayCollision : public ::RayCollision {
     }
 
     /**
+     * Get collision info between ray and bounding box
+     */
+    RayCollision(const ::Ray& ray, const ::BoundingBox& box) {
+        set(::GetRayCollisionBox(ray, box));
+    }
+
+    /**
      * Get collision info between ray and mesh
      */
     RayCollision(const ::Ray& ray, const ::Mesh& mesh, const ::Matrix& transform) {
@@ -31,6 +38,20 @@ class RayCollision : public ::RayCollision {
      */
     RayCollision(const ::Ray& ray, const ::Model& model) {
         set(::GetRayCollisionModel(ray, model));
+    }
+
+    /**
+     * Get collision info between ray and quad
+     */
+    RayCollision(const ::Ray& ray, ::Vector3 p1, ::Vector3 p2, ::Vector3 p3, ::Vector3 p4) {
+        set(::GetRayCollisionQuad(ray, p1, p2, p3, p4));
+    }
+
+    /**
+     * Get collision info between ray and sphere
+     */
+    RayCollision(const ::Ray& ray, ::Vector3 center, float radius) {
+        set(::GetRayCollisionSphere(ray, center, radius));
     }
 
     /**


### PR DESCRIPTION
Not all `GetRayCollision` functions are abstracted by `raylib::RayCollision` constructors. This pull request provides these abstractions for the rest of these functions.