### PR TITLE
Add shorthand class names like RTexture, RFont, RVector2, etc

### DIFF
--- a/include/AudioDevice.hpp
+++ b/include/AudioDevice.hpp
@@ -66,5 +66,6 @@ class AudioDevice {
     }
 };
 }  // namespace raylib
+using RAudioDevice = raylib::AudioDevice;
 
 #endif  // RAYLIB_CPP_INCLUDE_AUDIODEVICE_HPP_

--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -186,5 +186,6 @@ class AudioStream : public ::AudioStream {
     }
 };
 }  // namespace raylib
+using RAudioStream = raylib::AudioStream;
 
 #endif  // RAYLIB_CPP_INCLUDE_AUDIOSTREAM_HPP_

--- a/include/BoundingBox.hpp
+++ b/include/BoundingBox.hpp
@@ -75,5 +75,6 @@ class BoundingBox : public ::BoundingBox {
     }
 };
 }  // namespace raylib
+using RBoundingBox = raylib::BoundingBox;
 
 #endif  // RAYLIB_CPP_INCLUDE_BOUNDINGBOX_HPP_

--- a/include/Camera2D.hpp
+++ b/include/Camera2D.hpp
@@ -69,5 +69,6 @@ class Camera2D : public ::Camera2D {
     }
 };
 }  // namespace raylib
+using RCamera2D = raylib::Camera2D;
 
 #endif  // RAYLIB_CPP_INCLUDE_CAMERA2D_HPP_

--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -160,5 +160,7 @@ class Camera3D : public ::Camera3D {
 
 typedef Camera3D Camera;
 }  // namespace raylib
+using RCamera = raylib::Camera;
+using RCamera3D = raylib::Camera3D;
 
 #endif  // RAYLIB_CPP_INCLUDE_CAMERA3D_HPP_

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -254,5 +254,6 @@ class Color : public ::Color {
 };
 
 }  // namespace raylib
+using RColor = raylib::Color;
 
 #endif  // RAYLIB_CPP_INCLUDE_COLOR_HPP_

--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -247,5 +247,6 @@ class Font : public ::Font {
     }
 };
 }  // namespace raylib
+using RFont = raylib::Font;
 
 #endif  // RAYLIB_CPP_INCLUDE_FONT_HPP_

--- a/include/Gamepad.hpp
+++ b/include/Gamepad.hpp
@@ -114,5 +114,6 @@ class Gamepad {
     }
 };
 }  // namespace raylib
+using RGamepad = raylib::Gamepad;
 
 #endif  // RAYLIB_CPP_INCLUDE_GAMEPAD_HPP_

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -728,5 +728,6 @@ class Image : public ::Image {
     }
 };
 }  // namespace raylib
+using RImage = raylib::Image;
 
 #endif  // RAYLIB_CPP_INCLUDE_IMAGE_HPP_

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -118,5 +118,6 @@ class Material : public ::Material {
     }
 };
 }  // namespace raylib
+using RMaterial = raylib::Material;
 
 #endif  // RAYLIB_CPP_INCLUDE_MATERIAL_HPP_

--- a/include/Matrix.hpp
+++ b/include/Matrix.hpp
@@ -211,6 +211,6 @@ class Matrix : public ::Matrix {
     }
 };
 }  // namespace raylib
-
+using RMatrix = raylib::Matrix;
 
 #endif  // RAYLIB_CPP_INCLUDE_MATRIX_HPP_

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -302,5 +302,6 @@ class Mesh : public ::Mesh {
     }
 };
 }  // namespace raylib
+using RMesh = raylib::Mesh;
 
 #endif  // RAYLIB_CPP_INCLUDE_MESH_HPP_

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -237,5 +237,6 @@ class Model : public ::Model {
 };
 
 }  // namespace raylib
+using RModel = raylib::Model;
 
 #endif  // RAYLIB_CPP_INCLUDE_MODEL_HPP_

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -105,5 +105,6 @@ class ModelAnimation : public ::ModelAnimation {
     }
 };
 }  // namespace raylib
+using RModelAnimation = raylib::ModelAnimation;
 
 #endif  // RAYLIB_CPP_INCLUDE_MODELANIMATION_HPP_

--- a/include/Mouse.hpp
+++ b/include/Mouse.hpp
@@ -114,5 +114,6 @@ class Mouse {
     }
 };
 }  // namespace raylib
+using RMouse = raylib::Mouse;
 
 #endif  // RAYLIB_CPP_INCLUDE_MOUSE_HPP_

--- a/include/Music.hpp
+++ b/include/Music.hpp
@@ -226,5 +226,6 @@ class Music : public ::Music {
     }
 };
 }  // namespace raylib
+using RMusic = raylib::Music;
 
 #endif  // RAYLIB_CPP_INCLUDE_MUSIC_HPP_

--- a/include/Physics.hpp
+++ b/include/Physics.hpp
@@ -117,5 +117,6 @@ class Physics {
     }
 };
 }  // namespace raylib
+using RPhysics = raylib::Physics;
 
 #endif  // RAYLIB_CPP_INCLUDE_PHYSICS_HPP_

--- a/include/Ray.hpp
+++ b/include/Ray.hpp
@@ -95,5 +95,6 @@ class Ray : public ::Ray {
     }
 };
 }  // namespace raylib
+using RRay = raylib::Ray;
 
 #endif  // RAYLIB_CPP_INCLUDE_RAY_HPP_

--- a/include/RayCollision.hpp
+++ b/include/RayCollision.hpp
@@ -80,5 +80,6 @@ class RayCollision : public ::RayCollision {
     }
 };
 }  // namespace raylib
+using RRayCollision = raylib::RayCollision;
 
 #endif  // RAYLIB_CPP_INCLUDE_RAYCOLLISION_HPP_

--- a/include/Rectangle.hpp
+++ b/include/Rectangle.hpp
@@ -167,5 +167,6 @@ class Rectangle : public ::Rectangle {
     }
 };
 }  // namespace raylib
+using RRectangle = raylib::Rectangle;
 
 #endif  // RAYLIB_CPP_INCLUDE_RECTANGLE_HPP_

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -114,5 +114,7 @@ class RenderTexture : public ::RenderTexture {
 };
 typedef RenderTexture RenderTexture2D;
 }  // namespace raylib
+using RRenderTexture = raylib::RenderTexture;
+using RRenderTexture2D = raylib::RenderTexture2D;
 
 #endif  // RAYLIB_CPP_INCLUDE_RENDERTEXTURE_HPP_

--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -176,5 +176,6 @@ class Shader : public ::Shader {
     }
 };
 }  // namespace raylib
+using RShader = raylib::Shader;
 
 #endif  // RAYLIB_CPP_INCLUDE_SHADER_HPP_

--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -208,5 +208,6 @@ class Sound : public ::Sound {
     }
 };
 }  // namespace raylib
+using RSound = raylib::Sound;
 
 #endif  // RAYLIB_CPP_INCLUDE_SOUND_HPP_

--- a/include/Text.hpp
+++ b/include/Text.hpp
@@ -206,5 +206,6 @@ class Text {
     }
 };
 }  // namespace raylib
+using RText = raylib::Text;
 
 #endif  // RAYLIB_CPP_INCLUDE_TEXT_HPP_

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -321,5 +321,8 @@ typedef Texture Texture2D;
 typedef Texture TextureCubemap;
 
 }  // namespace raylib
+using RTexture = raylib::Texture;
+using RTexture2D = raylib::Texture2D;
+using RTextureCubemap = raylib::TextureCubemap;
 
 #endif  // RAYLIB_CPP_INCLUDE_TEXTURE_HPP_

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -391,5 +391,6 @@ class Vector2 : public ::Vector2 {
 };
 
 }  // namespace raylib
+using RVector2 = raylib::Vector2;
 
 #endif  // RAYLIB_CPP_INCLUDE_VECTOR2_HPP_

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -362,5 +362,6 @@ class Vector3 : public ::Vector3 {
     }
 };
 }  // namespace raylib
+using RVector3 = raylib::Vector3;
 
 #endif  // RAYLIB_CPP_INCLUDE_VECTOR3_HPP_

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -165,5 +165,7 @@ class Vector4 : public ::Vector4 {
 // Alias the Vector4 as Quaternion.
 typedef Vector4 Quaternion;
 }  // namespace raylib
+using RVector4 = raylib::Vector4;
+using RQuaternion = raylib::Quaternion;
 
 #endif  // RAYLIB_CPP_INCLUDE_VECTOR4_HPP_

--- a/include/VrStereoConfig.hpp
+++ b/include/VrStereoConfig.hpp
@@ -72,5 +72,6 @@ class VrStereoConfig : public ::VrStereoConfig  {
     }
 };
 }  // namespace raylib
+using RVrStereoConfig = raylib::VrStereoConfig;
 
 #endif  // RAYLIB_CPP_INCLUDE_VRSTEREOCONFIG_HPP_

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -221,5 +221,6 @@ class Wave : public ::Wave {
 };
 
 }  // namespace raylib
+using RWave = raylib::Wave;
 
 #endif  // RAYLIB_CPP_INCLUDE_WAVE_HPP_

--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -359,5 +359,6 @@ class Window {
     }
 };
 }  // namespace raylib
+using RWindow = raylib::Window;
 
 #endif  // RAYLIB_CPP_INCLUDE_WINDOW_HPP_


### PR DESCRIPTION
Remove the use to add raylib::Something
Coming from #199 