### PR TITLE
return of stackaddress pointer

### DIFF
--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -362,7 +362,7 @@ class Window {
     /**
      * Get clipboard text content
      */
-    inline const std::string& GetClipboardText() {
+    inline const std::string GetClipboardText() {
         return ::GetClipboardText();
     }
 


### PR DESCRIPTION
create a new string object instead of passing down a const string reference