### PR TITLE
Removed physac.hpp from the installed files list

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -22,7 +22,6 @@ install(FILES
     ModelAnimation.hpp
     Mouse.hpp
     Music.hpp
-    physac.hpp
     Ray.hpp
     RayCollision.hpp
     RaylibException.hpp


### PR DESCRIPTION
The file physac.hpp got removed in
d19cbccebb0196945693131c7ee3c8a47c5c96ff, but remained in `install/CMakeLists.txt`, causing `cmake --install` to fail.

Just removing it from the list minimizes changes, but seeing as every `.hpp` file gets added to the install list maybe something like this would be a better fit?
```cmake
file(GLOB INSTALL_FILES "*.hpp")
install(FILES ${INSTALL_FILES})
```