### PR TITLE
Replaced GenImageGradientH / V with GenImageGradientLinear

### DIFF
--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -131,17 +131,10 @@ class Image : public ::Image {
     }
 
     /**
-     * Generate image: vertical gradient
+     * Generate image: linear gradient
      */
-    static ::Image GradientV(int width, int height, ::Color top, ::Color bottom) {
-        return ::GenImageGradientV(width, height, top, bottom);
-    }
-
-    /**
-     * Generate image: horizontal gradient
-     */
-    static ::Image GradientH(int width, int height, ::Color left, ::Color right) {
-        return ::GenImageGradientH(width, height, left, right);
+    static ::Image GradientLinear(int width, int height, int direction, ::Color start, ::Color end) {
+        return ::GenImageGradientLinear(width, height, direction, start, end);
     }
 
     /**


### PR DESCRIPTION
GenImageGradientH and GenImageGradientV were recently replaced by GenImageGradientLinear: https://github.com/raysan5/raylib/pull/3074/commits/2633eb0579c0fbe65aed337ef83fa9a7fe5415b4

Updated Image.hpp to match this change. Thanks!