### PR TITLE
Update to raylib 4.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 project (raylib_cpp
-    VERSION 4.5.0
+    VERSION 4.6.0
     DESCRIPTION "raylib-cpp C++ Object Oriented Wrapper for raylib"
     HOMEPAGE_URL "https://github.com/robloach/raylib-cpp"
     LANGUAGES C CXX

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![raylib-cpp Logo](projects/Doxygen/raylib-cpp_256x256.png)
 
-# raylib-cpp ![Targeting raylib 4.5](https://img.shields.io/badge/for_raylib-4.5-blue) [![Tests](https://github.com/RobLoach/raylib-cpp/workflows/Tests/badge.svg)](https://github.com/RobLoach/raylib-cpp/actions?query=workflow%3ATests+branch%3Amaster) [![License](https://img.shields.io/badge/license-zlib%2Flibpng-blue.svg)](LICENSE)
+# raylib-cpp ![Targeting raylib 4.6](https://img.shields.io/badge/for_raylib-4.5-blue) [![Tests](https://github.com/RobLoach/raylib-cpp/workflows/Tests/badge.svg)](https://github.com/RobLoach/raylib-cpp/actions?query=workflow%3ATests+branch%3Amaster) [![License](https://img.shields.io/badge/license-zlib%2Flibpng-blue.svg)](LICENSE)
 
 [raylib-cpp](https://github.com/robloach/raylib-cpp) is a C++ wrapper library for [raylib](https://www.raylib.com), a simple and easy-to-use library to enjoy videogames programming. This C++ header provides object-oriented wrappers around *raylib*'s struct interfaces. *raylib-cpp* is not required to use *raylib* in C++, but the classes do bring using the raylib API more inline with C++'s language paradigm.
 

--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "raylib-cpp",
-  "version": "4.5.1",
+  "version": "4.6.0-alpha1",
   "repo": "RobLoach/raylib-cpp",
   "description": "raylib-cpp: C++ Object-Oriented Wrapper for raylib",
   "homepage": "https://github.com/robloach/raylib-cpp",

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT raylib_FOUND)
         FetchContent_Declare(
         raylib
         GIT_REPOSITORY https://github.com/raysan5/raylib.git
-        GIT_TAG 4.5.0
+        GIT_TAG 5e1a81555ca130e2c6544add0e2391a8763e7e2a
     )
     FetchContent_GetProperties(raylib)
     if (NOT raylib_POPULATED) # Have we downloaded raylib yet?

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT raylib_FOUND)
         FetchContent_Declare(
         raylib
         GIT_REPOSITORY https://github.com/raysan5/raylib.git
-        GIT_TAG 5e1a81555ca130e2c6544add0e2391a8763e7e2a
+        GIT_TAG 334e96d470c5cb09d154e1c849d04adb721a7a8c
     )
     FetchContent_GetProperties(raylib)
     if (NOT raylib_POPULATED) # Have we downloaded raylib yet?

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -196,6 +196,27 @@ class Color : public ::Color {
     }
 
     /**
+     * Get color multiplied with another color
+     */
+    inline Color Tint(::Color tint) {
+        return ::ColorTint(*this, tint);
+    }
+
+    /**
+     * Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
+     */
+    inline Color Brightness(float factor) {
+        return ::ColorBrightness(*this, factor);
+    }
+
+    /**
+     * Get color with contrast correction, contrast values between -1.0f and 1.0f
+     */
+    inline Color Contrast(float contrast) {
+        return ::ColorContrast(*this, contrast);
+    }
+
+    /**
      * Returns color with alpha applied, alpha goes from 0.0f to 1.0f
      */
     Color Alpha(float alpha) const {

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -299,6 +299,13 @@ class Image : public ::Image {
     }
 
     /**
+     * Export image to memory buffer
+     */
+    inline unsigned char* ExportToMemory(const char *fileType, int *fileSize) {
+        return ::ExportImageToMemory(*this, fileType, fileSize);
+    }
+
+    /**
      * Export image as code file defining an array of bytes, returns true on success
      *
      * @throws raylib::RaylibException Thrown if the image failed to load from the file.
@@ -474,6 +481,14 @@ class Image : public ::Image {
      */
     inline Image& FlipHorizontal() {
         ::ImageFlipHorizontal(this);
+        return *this;
+    }
+
+    /**
+     * Rotate image by input angle in degrees (-359 to 359)
+     */
+    inline Image& Rotate(int degrees) {
+        ::ImageRotate(this, degrees);
         return *this;
     }
 

--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -223,6 +223,14 @@ class Window {
     }
 
     /**
+     * Set icon for window (multiple images, RGBA 32bit, only PLATFORM_DESKTOP)
+     */
+    inline Window& SetIcons(Image* images, int count) {
+        ::SetWindowIcons(images, count);
+        return *this;
+    }
+
+    /**
      * Set title for window
      */
     inline Window& SetTitle(const std::string& title) {
@@ -282,6 +290,14 @@ class Window {
      */
     inline Window& SetOpacity(float opacity) {
         ::SetWindowOpacity(opacity);
+        return *this;
+    }
+
+    /**
+     * Set window focused (only PLATFORM_DESKTOP)
+     */
+    inline Window& SetFocused() {
+        ::SetWindowFocused();
         return *this;
     }
 

--- a/include/raylib.hpp
+++ b/include/raylib.hpp
@@ -14,12 +14,14 @@ extern "C" {
 
 #include RAYLIB_H_FILE // NOLINT
 
-#if !defined(RAYLIB_VERSION_MAJOR) || !defined(RAYLIB_VERSION_MINOR) || RAYLIB_VERSION_MAJOR < 4 || RAYLIB_VERSION_MINOR < 5
-#error "raylib-cpp requires at least raylib 4.5.0"
+#if !defined(RAYLIB_VERSION_MAJOR) || !defined(RAYLIB_VERSION_MINOR)
+#if RAYLIB_VERSION_MAJOR < 4 || RAYLIB_VERSION_MINOR < 6
+#error "raylib-cpp requires at least raylib 4.6.0"
+#endif
 #endif
 
-#if RAYLIB_VERSION_MINOR > 5
-#error "raylib-cpp targets raylib 4.5. Use the `next` branch for the next version of raylib."
+#if RAYLIB_VERSION_MINOR > 6
+#error "raylib-cpp targets raylib 4.6. Use the `next` branch for the next version of raylib."
 #endif
 
 #ifdef __cplusplus

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raylib-cpp",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "raylib-cpp: C++ Object-Oriented Wrapper for raylib",
   "main": "index.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raylib-cpp
-  "version": "4.6.0",
+  "version": "4.6.0-alpha1",
   "description": "raylib-cpp: C++ Object-Oriented Wrapper for raylib",
   "main": "index.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "raylib-cpp
+  "name": "raylib-cpp",
   "version": "4.6.0-alpha1",
   "description": "raylib-cpp: C++ Object-Oriented Wrapper for raylib",
   "main": "index.js",


### PR DESCRIPTION
Use the `next` branch to target the next version of raylib.