### PR TITLE
Error out when on raylib >4.5

### DIFF
--- a/include/raylib.hpp
+++ b/include/raylib.hpp
@@ -18,6 +18,10 @@ extern "C" {
 #error "raylib-cpp requires at least raylib 4.5.0"
 #endif
 
+#if RAYLIB_VERSION_MINOR > 5
+#error "raylib-cpp targets raylib 4.5. Use the `next` branch for the next version of raylib."
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
When using raylib 4.6, error out. People get confused when using raylib 4.6-dev, so having it full on error out may be the best option.

Fixes #242
