### PR TITLE
Add -s flags to projects/CMake/CMakeLists.txt for newer versions of raylib

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -35,6 +35,9 @@ target_link_libraries(${PROJECT_NAME} PUBLIC raylib raylib_cpp)
 if (${PLATFORM} STREQUAL "Web")
     # Tell Emscripten to build an example.html file.
     set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
+
+    # Required linker flags for using Raylib with Emscripten
+    target_link_options(${PROJECT_NAME} PRIVATE -sEXPORTED_FUNCTIONS=['_main','_malloc'] -sEXPORTED_RUNTIME_METHODS=ccall -sUSE_GLFW=3)
 endif()
 
 # That's it! You should have an example executable that you can run. Have fun!

--- a/projects/CMake/README.md
+++ b/projects/CMake/README.md
@@ -16,7 +16,7 @@ make
 ```
 mkdir build
 cd build
-emcmake cmake .. -DPLATFORM=Web -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-s USE_GLFW=3"
+emcmake cmake .. -DPLATFORM=Web -DCMAKE_BUILD_TYPE=Release
 emmake make
 ```
 


### PR DESCRIPTION
I have found that the current Cmake template no longer works with the current version of raylib. After some debugging I discovered that some extra linker options where required. The "-s USE_GLFW=3" flag was moved from the command line arguments into Cmakelists.txt so that all the flags are in the same place.