### PR TITLE
Fix const correctness for Vector2, Vector3, and Vector4

### DIFF
--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -35,7 +35,7 @@ class Vector2 : public ::Vector2 {
     /**
      * Determine whether or not the vectors are equal.
      */
-    bool operator==(const ::Vector2& other) {
+    bool operator==(const ::Vector2& other) const {
         return x == other.x
             && y == other.y;
     }
@@ -43,7 +43,7 @@ class Vector2 : public ::Vector2 {
     /**
      * Determines if the vectors are not equal.
      */
-    bool operator!=(const ::Vector2& other) {
+    bool operator!=(const ::Vector2& other) const {
         return !(*this == other);
     }
 
@@ -211,7 +211,7 @@ class Vector2 : public ::Vector2 {
     /**
      * Transforms a Vector2 by a given Matrix
      */
-    inline Vector2 Transform(::Matrix mat) {
+    inline Vector2 Transform(::Matrix mat) const {
         return ::Vector2Transform(*this, mat);
     }
 
@@ -246,28 +246,28 @@ class Vector2 : public ::Vector2 {
     /**
      * Invert the given vector
      */
-    inline Vector2 Invert() {
+    inline Vector2 Invert() const {
         return ::Vector2Invert(*this);
     }
 
     /**
      * Clamp the components of the vector between
      */
-    inline Vector2 Clamp(::Vector2 min, ::Vector2 max) {
+    inline Vector2 Clamp(::Vector2 min, ::Vector2 max) const {
         return ::Vector2Clamp(*this, min, max);
     }
 
     /**
      * // Clamp the magnitude of the vector between two min and max values
      */
-    inline Vector2 Clamp(float min, float max) {
+    inline Vector2 Clamp(float min, float max) const {
         return ::Vector2ClampValue(*this, min, max);
     }
 
     /**
      * Check whether two given vectors are almost equal
      */
-    inline int Equals(::Vector2 q) {
+    inline int Equals(::Vector2 q) const {
         return ::Vector2Equals(*this, q);
     }
 
@@ -302,7 +302,7 @@ class Vector2 : public ::Vector2 {
     /**
      * Calculate square distance between two vectors
      */
-    inline float DistanceSqr(::Vector2 v2) {
+    inline float DistanceSqr(::Vector2 v2) const {
         return ::Vector2DistanceSqr(*this, v2);
     }
 
@@ -418,7 +418,7 @@ class Vector2 : public ::Vector2 {
     /**
      * Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
      */
-    inline bool CheckCollisionPointLine(::Vector2 p1, ::Vector2 p2, int threshold = 1) {
+    inline bool CheckCollisionPointLine(::Vector2 p1, ::Vector2 p2, int threshold = 1) const {
         return ::CheckCollisionPointLine(*this, p1, p2, threshold);
     }
 

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -35,13 +35,13 @@ class Vector3 : public ::Vector3 {
         return *this;
     }
 
-    bool operator==(const ::Vector3& other) {
+    bool operator==(const ::Vector3& other) const {
         return x == other.x
             && y == other.y
             && z == other.z;
     }
 
-    bool operator!=(const ::Vector3& other) {
+    bool operator!=(const ::Vector3& other) const {
         return !(*this == other);
     }
 
@@ -49,14 +49,14 @@ class Vector3 : public ::Vector3 {
     /**
      * Add two vectors
      */
-    inline Vector3 Add(const ::Vector3& vector3) {
+    inline Vector3 Add(const ::Vector3& vector3) const {
         return Vector3Add(*this, vector3);
     }
 
     /**
      * Add two vectors
      */
-    inline Vector3 operator+(const ::Vector3& vector3) {
+    inline Vector3 operator+(const ::Vector3& vector3) const {
         return Vector3Add(*this, vector3);
     }
 
@@ -69,14 +69,14 @@ class Vector3 : public ::Vector3 {
     /**
      * Subtract two vectors.
      */
-    inline Vector3 Subtract(const ::Vector3& vector3) {
+    inline Vector3 Subtract(const ::Vector3& vector3) const {
         return Vector3Subtract(*this, vector3);
     }
 
     /**
      * Subtract two vectors.
      */
-    inline Vector3 operator-(const ::Vector3& vector3) {
+    inline Vector3 operator-(const ::Vector3& vector3) const {
         return Vector3Subtract(*this, vector3);
     }
 
@@ -89,14 +89,14 @@ class Vector3 : public ::Vector3 {
     /**
      * Negate provided vector (invert direction)
      */
-    inline Vector3 Negate() {
+    inline Vector3 Negate() const {
         return Vector3Negate(*this);
     }
 
     /**
      * Negate provided vector (invert direction)
      */
-    inline Vector3 operator-() {
+    inline Vector3 operator-() const {
         return Vector3Negate(*this);
     }
 
@@ -207,7 +207,7 @@ class Vector3 : public ::Vector3 {
         return Vector3Normalize(*this);
     }
 
-    inline float DotProduct(const ::Vector3& vector3) {
+    inline float DotProduct(const ::Vector3& vector3) const {
         return Vector3DotProduct(*this, vector3);
     }
 
@@ -235,7 +235,7 @@ class Vector3 : public ::Vector3 {
         return Vector3Transform(*this, matrix);
     }
 
-    inline Vector3 RotateByQuaternion(const ::Quaternion& quaternion) {
+    inline Vector3 RotateByQuaternion(const ::Quaternion& quaternion) const {
         return Vector3RotateByQuaternion(*this, quaternion);
     }
 
@@ -243,15 +243,15 @@ class Vector3 : public ::Vector3 {
         return Vector3Reflect(*this, normal);
     }
 
-    inline Vector3 Min(const ::Vector3& vector3) {
+    inline Vector3 Min(const ::Vector3& vector3) const {
         return Vector3Min(*this, vector3);
     }
 
-    inline Vector3 Max(const ::Vector3& vector3) {
+    inline Vector3 Max(const ::Vector3& vector3) const {
         return Vector3Max(*this, vector3);
     }
 
-    inline Vector3 Barycenter(const ::Vector3& a, const ::Vector3& b, const ::Vector3& c) {
+    inline Vector3 Barycenter(const ::Vector3& a, const ::Vector3& b, const ::Vector3& c) const {
         return Vector3Barycenter(*this, a, b, c);
     }
 
@@ -325,7 +325,7 @@ class Vector3 : public ::Vector3 {
     /**
      * Detect collision between two spheres
      */
-    inline bool CheckCollision(float radius1, const ::Vector3& center2, float radius2) {
+    inline bool CheckCollision(float radius1, const ::Vector3& center2, float radius2) const {
         return CheckCollisionSpheres(*this, radius1, center2, radius2);
     }
 

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -39,18 +39,18 @@ class Vector4 : public ::Vector4 {
         return *this;
     }
 
-    bool operator==(const ::Vector4& other) {
+    bool operator==(const ::Vector4& other) const {
         return x == other.x
             && y == other.y
             && z == other.z
             && w == other.w;
     }
 
-    bool operator!=(const ::Vector4& other) {
+    bool operator!=(const ::Vector4& other) const {
         return !(*this == other);
     }
 
-    inline ::Rectangle ToRectangle() {
+    inline ::Rectangle ToRectangle() const {
         return {x, y, z, w};
     }
 
@@ -95,14 +95,14 @@ class Vector4 : public ::Vector4 {
         return QuaternionInvert(*this);
     }
 
-    inline void ToAxisAngle(::Vector3 *outAxis, float *outAngle) {
+    inline void ToAxisAngle(::Vector3 *outAxis, float *outAngle) const {
         QuaternionToAxisAngle(*this, outAxis, outAngle);
     }
 
     /**
      * Get the rotation angle and axis for a given quaternion
      */
-    std::pair<Vector3, float> ToAxisAngle() {
+    std::pair<Vector3, float> ToAxisAngle() const {
         Vector3 outAxis;
         float outAngle;
         QuaternionToAxisAngle(*this, &outAxis, &outAngle);
@@ -110,7 +110,7 @@ class Vector4 : public ::Vector4 {
         return std::pair<Vector3, float>(outAxis, outAngle);
     }
 
-    inline Vector4 Transform(const ::Matrix& matrix) {
+    inline Vector4 Transform(const ::Matrix& matrix) const {
         return ::QuaternionTransform(*this, matrix);
     }
 
@@ -138,7 +138,7 @@ class Vector4 : public ::Vector4 {
         return ::QuaternionFromEuler(vector3.x, vector3.y, vector3.z);
     }
 
-    inline Vector3 ToEuler() {
+    inline Vector3 ToEuler() const {
         return ::QuaternionToEuler(*this);
     }
 #endif
@@ -147,7 +147,7 @@ class Vector4 : public ::Vector4 {
         return ::ColorFromNormalized(*this);
     }
 
-    operator Color() {
+    operator Color() const {
         return ColorFromNormalized();
     }
 


### PR DESCRIPTION
… Vector4 classes.

This solves the issues of constness discussed [in Issue #246](https://github.com/RobLoach/raylib-cpp/issues/246), as well as adding const to a few other const member functions in the three Vector classes.