### PR TITLE
Adding ToString() and std::string cast to Color and Vector classes

### DIFF
--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -66,6 +66,16 @@ class Color : public ::Color {
         return ::ColorToInt(*this);
     }
 
+    inline std::string ToString() const {
+        std::ostringstream oss;
+        oss << "Color(" << r << ", " << g << ", " << b << ", " << a << ")";
+        return oss.str();
+    }
+
+    inline operator std::string() const {
+        return ToString();
+    }
+
     /**
      * Returns color with alpha applied, alpha goes from 0.0f to 1.0f
      */
@@ -208,13 +218,6 @@ class Color : public ::Color {
      */
     Color AlphaBlend(::Color dst, ::Color tint) const {
         return ::ColorAlphaBlend(dst, *this, tint);
-    }
-
-    inline std::string ToString() const
-    {
-        std::ostringstream oss;
-        oss << "Color(" << r << ", " << g << ", " << b << ", " << a << ")";
-        return oss.str();
     }
 
     inline static Color LightGray() { return LIGHTGRAY; }

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -1,7 +1,6 @@
 #ifndef RAYLIB_CPP_INCLUDE_COLOR_HPP_
 #define RAYLIB_CPP_INCLUDE_COLOR_HPP_
 
-#include <sstream>
 #include <string>
 
 #include "./raylib.hpp"
@@ -67,9 +66,7 @@ class Color : public ::Color {
     }
 
     inline std::string ToString() const {
-        std::ostringstream oss;
-        oss << "Color(" << r << ", " << g << ", " << b << ", " << a << ")";
-        return oss.str();
+        return TextFormat("Color(%d, %d, %d, %d)", r, g, b, a);
     }
 
     inline operator std::string() const {

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -1,6 +1,7 @@
 #ifndef RAYLIB_CPP_INCLUDE_COLOR_HPP_
 #define RAYLIB_CPP_INCLUDE_COLOR_HPP_
 
+#include <sstream>
 #include <string>
 
 #include "./raylib.hpp"
@@ -207,6 +208,13 @@ class Color : public ::Color {
      */
     Color AlphaBlend(::Color dst, ::Color tint) const {
         return ::ColorAlphaBlend(dst, *this, tint);
+    }
+
+    inline std::string ToString() const
+    {
+        std::ostringstream oss;
+        oss << "Color(" << r << ", " << g << ", " << b << ", " << a << ")";
+        return oss.str();
     }
 
     inline static Color LightGray() { return LIGHTGRAY; }

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -5,6 +5,8 @@
 #include <cmath>
 #endif
 
+#include <sstream>
+
 #include "./raylib.hpp"
 #include "./raymath.hpp"
 #include "./raylib-cpp-utils.hpp"
@@ -420,6 +422,13 @@ class Vector2 : public ::Vector2 {
      */
     inline bool CheckCollisionPointLine(::Vector2 p1, ::Vector2 p2, int threshold = 1) {
         return ::CheckCollisionPointLine(*this, p1, p2, threshold);
+    }
+
+    inline std::string ToString() const
+    {
+        std::ostringstream oss;
+        oss << "Vector2(" << x << ", " << y << ")";
+        return oss.str();
     }
 
  private:

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -5,8 +5,6 @@
 #include <cmath>
 #endif
 
-#include <sstream>
-
 #include "./raylib.hpp"
 #include "./raymath.hpp"
 #include "./raylib-cpp-utils.hpp"
@@ -50,9 +48,7 @@ class Vector2 : public ::Vector2 {
     }
 
     inline std::string ToString() const {
-        std::ostringstream oss;
-        oss << "Vector2(" << x << ", " << y << ")";
-        return oss.str();
+        return TextFormat("Vector2(%f, %f)", x, y);
     }
 
     inline operator std::string() const {

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -49,6 +49,16 @@ class Vector2 : public ::Vector2 {
         return !(*this == other);
     }
 
+    inline std::string ToString() const {
+        std::ostringstream oss;
+        oss << "Vector2(" << x << ", " << y << ")";
+        return oss.str();
+    }
+
+    inline operator std::string() const {
+        return ToString();
+    }
+
 #ifndef RAYLIB_CPP_NO_MATH
     /**
      * Add two vectors (v1 + v2)
@@ -422,13 +432,6 @@ class Vector2 : public ::Vector2 {
      */
     inline bool CheckCollisionPointLine(::Vector2 p1, ::Vector2 p2, int threshold = 1) {
         return ::CheckCollisionPointLine(*this, p1, p2, threshold);
-    }
-
-    inline std::string ToString() const
-    {
-        std::ostringstream oss;
-        oss << "Vector2(" << x << ", " << y << ")";
-        return oss.str();
     }
 
  private:

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -47,6 +47,16 @@ class Vector3 : public ::Vector3 {
         return !(*this == other);
     }
 
+    inline std::string ToString() const {
+        std::ostringstream oss;
+        oss << "Vector3(" << x << ", " << y << ", " << z << ")";
+        return oss.str();
+    }
+
+    inline operator std::string() const {
+        return ToString();
+    }
+
 #ifndef RAYLIB_CPP_NO_MATH
     /**
      * Add two vectors
@@ -329,13 +339,6 @@ class Vector3 : public ::Vector3 {
      */
     inline bool CheckCollision(float radius1, const ::Vector3& center2, float radius2) {
         return CheckCollisionSpheres(*this, radius1, center2, radius2);
-    }
-
-    inline std::string ToString() const
-    {
-        std::ostringstream oss;
-        oss << "Vector3(" << x << ", " << y << ", " << z << ")";
-        return oss.str();
     }
 
  private:

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -5,8 +5,6 @@
 #include <cmath>
 #endif
 
-#include <sstream>
-
 #include "./raylib.hpp"
 #include "./raymath.hpp"
 #include "./raylib-cpp-utils.hpp"
@@ -48,9 +46,7 @@ class Vector3 : public ::Vector3 {
     }
 
     inline std::string ToString() const {
-        std::ostringstream oss;
-        oss << "Vector3(" << x << ", " << y << ", " << z << ")";
-        return oss.str();
+        return TextFormat("Vector3(%f, %f, %f)", x, y, z);
     }
 
     inline operator std::string() const {

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -5,6 +5,8 @@
 #include <cmath>
 #endif
 
+#include <sstream>
+
 #include "./raylib.hpp"
 #include "./raymath.hpp"
 #include "./raylib-cpp-utils.hpp"
@@ -327,6 +329,13 @@ class Vector3 : public ::Vector3 {
      */
     inline bool CheckCollision(float radius1, const ::Vector3& center2, float radius2) {
         return CheckCollisionSpheres(*this, radius1, center2, radius2);
+    }
+
+    inline std::string ToString() const
+    {
+        std::ostringstream oss;
+        oss << "Vector3(" << x << ", " << y << ", " << z << ")";
+        return oss.str();
     }
 
  private:

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -6,8 +6,6 @@
 #include <utility>
 #endif
 
-#include <sstream>
-
 #include "./raylib.hpp"
 #include "./raymath.hpp"
 #include "./raylib-cpp-utils.hpp"
@@ -61,9 +59,7 @@ class Vector4 : public ::Vector4 {
     }
 
     inline std::string ToString() const {
-        std::ostringstream oss;
-        oss << "Vector4(" << x << ", " << y << ", " << z << ", " << w << ")";
-        return oss.str();
+        return TextFormat("Vector4(%f, %f, %f, %f)", x, y, z, w);
     }
 
     inline operator std::string() const {

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -6,6 +6,8 @@
 #include <utility>
 #endif
 
+#include <sstream>
+
 #include "./raylib.hpp"
 #include "./raymath.hpp"
 #include "./raylib-cpp-utils.hpp"
@@ -149,6 +151,13 @@ class Vector4 : public ::Vector4 {
 
     operator Color() {
         return ColorFromNormalized();
+    }
+
+    inline std::string ToString() const
+    {
+        std::ostringstream oss;
+        oss << "Vector4(" << x << ", " << y << ", " << z << ", " << w << ")";
+        return oss.str();
     }
 
  private:

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -60,6 +60,16 @@ class Vector4 : public ::Vector4 {
         return {x, y, z, w};
     }
 
+    inline std::string ToString() const {
+        std::ostringstream oss;
+        oss << "Vector4(" << x << ", " << y << ", " << z << ", " << w << ")";
+        return oss.str();
+    }
+
+    inline operator std::string() const {
+        return ToString();
+    }
+
 #ifndef RAYLIB_CPP_NO_MATH
     inline Vector4 Multiply(const ::Vector4& vector4) const {
         return QuaternionMultiply(*this, vector4);
@@ -151,13 +161,6 @@ class Vector4 : public ::Vector4 {
 
     operator Color() {
         return ColorFromNormalized();
-    }
-
-    inline std::string ToString() const
-    {
-        std::ostringstream oss;
-        oss << "Vector4(" << x << ", " << y << ", " << z << ", " << w << ")";
-        return oss.str();
     }
 
  private:


### PR DESCRIPTION
This adds ToString() and operator std::string to Color and Vector classes. There are some other classes that could benefit from similar treatment, but we have to start somewhere.