### PR TITLE
Added overloads for const std::string& and const char* arguments

### DIFF
--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -45,6 +45,10 @@ class Shader : public ::Shader {
         return ::LoadShader(vsFileName.c_str(), fsFileName.c_str());
     }
 
+    static ::Shader Load(const char* vsFileName, const char* fsFileName) {
+        return ::LoadShader(vsFileName, fsFileName);
+    }
+
     /**
      * Load a shader from memory.
      *
@@ -52,6 +56,10 @@ class Shader : public ::Shader {
      */
     static ::Shader LoadFromMemory(const std::string& vsCode, const std::string& fsCode) {
         return ::LoadShaderFromMemory(vsCode.c_str(), fsCode.c_str());
+    }
+
+    static ::Shader LoadFromMemory(const char* vsCode, const char* fsCode) {
+        return ::LoadShaderFromMemory(vsCode, fsCode);
     }
 
     GETTERSETTER(unsigned int, Id, id)


### PR DESCRIPTION
This is primarily a suggestion, wouldn't adding an overload function `LoadFromMemory(const char* vsCode, const char* fsCode)` be more convenient in the case where we might, for example, want to load a fragment shader from memory with the default vertex shader?

For the sake of consistency, I've also added one for `static ::Shader Load(...)`, to see if it would be equally useful.