### PR TITLE
Changing access modifiers to `protected`

### DIFF
--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -211,7 +211,7 @@ class AudioStream : public ::AudioStream {
         }
     }
 
- private:
+ protected:
     void set(const ::AudioStream& stream) {
         buffer = stream.buffer;
         processor = stream.processor;

--- a/include/BoundingBox.hpp
+++ b/include/BoundingBox.hpp
@@ -70,7 +70,7 @@ class BoundingBox : public ::BoundingBox {
         return GetRayCollisionBox(ray, *this);
     }
 
- private:
+ protected:
     void set(const ::BoundingBox& box) {
         min = box.min;
         max = box.max;

--- a/include/Camera2D.hpp
+++ b/include/Camera2D.hpp
@@ -60,7 +60,7 @@ class Camera2D : public ::Camera2D {
         return ::GetWorldToScreen2D(position, *this);
     }
 
- private:
+ protected:
     void set(const ::Camera2D& camera) {
         offset = camera.offset;
         target = camera.target;

--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -119,7 +119,7 @@ class Camera3D : public ::Camera3D {
         ::DrawBillboardRec(*this, texture, sourceRec, center, size, tint);
     }
 
- private:
+ protected:
     void set(const ::Camera3D& camera) {
         position = camera.position;
         target = camera.target;

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -244,7 +244,7 @@ class Color : public ::Color {
     inline static Color Magenta() { return MAGENTA; }
     inline static Color RayWhite() { return RAYWHITE; }
 
- private:
+ protected:
     void set(const ::Color& color) {
         r = color.r;
         g = color.g;

--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -287,7 +287,7 @@ class Font : public ::Font {
         return ::ImageTextEx(*this, text.c_str(), fontSize, spacing, tint);
     }
 
- private:
+ protected:
     void set(const ::Font& font) {
         baseSize = font.baseSize;
         glyphCount = font.glyphCount;

--- a/include/Gamepad.hpp
+++ b/include/Gamepad.hpp
@@ -112,7 +112,7 @@ class Gamepad {
         return SetGamepadMappings(mappings.c_str());
     }
 
- private:
+ protected:
     inline void set(int gamepadNumber) {
         number = gamepadNumber;
     }

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -726,7 +726,7 @@ class Image : public ::Image {
         return ::IsImageReady(*this);
     }
 
- private:
+ protected:
     void set(const ::Image& image) {
         data = image.data;
         width = image.width;

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -116,7 +116,7 @@ class Material : public ::Material {
         return ::IsMaterialReady(*this);
     }
 
- private:
+ protected:
     void set(const ::Material& material) {
         shader = material.shader;
         maps = material.maps;

--- a/include/Matrix.hpp
+++ b/include/Matrix.hpp
@@ -205,7 +205,7 @@ class Matrix : public ::Matrix {
 
 #endif
 
- private:
+ protected:
     void set(const ::Matrix& mat) {
         m0 = mat.m0;
         m1 = mat.m1;

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -266,7 +266,7 @@ class Mesh : public ::Mesh {
         return ::LoadModelFromMesh(*this);
     }
 
- private:
+ protected:
     void set(const ::Mesh& mesh) {
         vertexCount = mesh.vertexCount;
         triangleCount = mesh.triangleCount;

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -220,7 +220,7 @@ class Model : public ::Model {
         }
     }
 
- private:
+ protected:
     void set(const ::Model& model) {
         transform = model.transform;
 

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -96,7 +96,7 @@ class ModelAnimation : public ::ModelAnimation {
         return ::IsModelAnimationValid(model, *this);
     }
 
- private:
+ protected:
     void set(const ::ModelAnimation& model) {
         boneCount = model.boneCount;
         frameCount = model.frameCount;

--- a/include/Music.hpp
+++ b/include/Music.hpp
@@ -223,7 +223,7 @@ class Music : public ::Music {
         return ::IsMusicReady(*this);
     }
 
- private:
+ protected:
     void set(const ::Music& music) {
         stream = music.stream;
         frameCount = music.frameCount;

--- a/include/Ray.hpp
+++ b/include/Ray.hpp
@@ -88,7 +88,7 @@ class Ray : public ::Ray {
         return ::GetMouseRay(::GetMousePosition(), camera);
     }
 
- private:
+ protected:
     inline void set(const ::Ray& ray) {
         position = ray.position;
         direction = ray.direction;

--- a/include/RayCollision.hpp
+++ b/include/RayCollision.hpp
@@ -64,7 +64,7 @@ class RayCollision : public ::RayCollision {
     GETTERSETTER(::Vector3, Position, point)
     GETTERSETTER(::Vector3, Normal, normal)
 
- private:
+ protected:
     void set(const ::RayCollision& ray) {
         hit = ray.hit;
         distance = ray.distance;

--- a/include/Rectangle.hpp
+++ b/include/Rectangle.hpp
@@ -146,7 +146,7 @@ class Rectangle : public ::Rectangle {
         return SetPosition(position.x, position.y);
     }
 
- private:
+ protected:
     void set(const ::Rectangle& rect) {
         x = rect.x;
         y = rect.y;

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -127,7 +127,7 @@ class RenderTexture : public ::RenderTexture {
         return ::IsRenderTextureReady(*this);
     }
 
- private:
+ protected:
     void set(const ::RenderTexture& renderTexture) {
         id = renderTexture.id;
         texture = renderTexture.texture;

--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -183,7 +183,7 @@ class Shader : public ::Shader {
         return id != 0 && locs != nullptr;
     }
 
- private:
+ protected:
     void set(const ::Shader& shader) {
         id = shader.id;
         locs = shader.locs;

--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -198,7 +198,7 @@ class Sound : public ::Sound {
         return ::IsSoundReady(*this);
     }
 
- private:
+ protected:
     void set(const ::Sound& sound) {
         frameCount = sound.frameCount;
         stream = sound.stream;

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -432,7 +432,7 @@ class Vector2 : public ::Vector2 {
         return ::CheckCollisionPointLine(*this, p1, p2, threshold);
     }
 
- private:
+ protected:
     void set(const ::Vector2& vec) {
         x = vec.x;
         y = vec.y;

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -339,7 +339,7 @@ class Vector3 : public ::Vector3 {
         return CheckCollisionSpheres(*this, radius1, center2, radius2);
     }
 
- private:
+ protected:
     void set(const ::Vector3& vec) {
         x = vec.x;
         y = vec.y;

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -161,7 +161,7 @@ class Vector4 : public ::Vector4 {
         return ColorFromNormalized();
     }
 
- private:
+ protected:
     void set(const ::Vector4& vec4) {
         x = vec4.x;
         y = vec4.y;

--- a/include/VrStereoConfig.hpp
+++ b/include/VrStereoConfig.hpp
@@ -51,7 +51,7 @@ class VrStereoConfig : public ::VrStereoConfig  {
         ::UnloadVrStereoConfig(*this);
     }
 
- private:
+ protected:
     void set(const ::VrStereoConfig& config) {
         projection[0] = config.projection[0];
         projection[1] = config.projection[1];

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -215,7 +215,7 @@ class Wave : public ::Wave {
         return ::IsWaveReady(*this);
     }
 
- private:
+ protected:
     void set(const ::Wave& wave) {
         frameCount = wave.frameCount;
         sampleRate = wave.sampleRate;


### PR DESCRIPTION
I suggest changing the access modifier of the member functions `set()` from `private` to `protected` because using this function can be beneficial and avoids casting on `this` in cases where one is writing classes that inherit.