### PR TITLE
Fix a recursive Mesh include in Model.hpp

### DIFF
--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -5,10 +5,10 @@
 
 #include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
-#include "./Mesh.hpp"
 #include "./RaylibException.hpp"
 
 namespace raylib {
+class Mesh;
 /**
  * Model type
  */


### PR DESCRIPTION
I corrected a small, unnecessary recursive inclusion problem and still added a forward declaration of `Mesh` just in case to avoid potential errors. `Model.hpp` only uses `Mesh` through pointers or references, so I think it's better this way.