### PR TITLE
Fix degrees to radians

### DIFF
--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -240,10 +240,10 @@ class Vector2 : public ::Vector2 {
     }
 
     /**
-     * Rotate Vector by float in Degrees
+     * Rotate Vector by float in radians
      */
-    inline Vector2 Rotate(float degrees) const {
-        return Vector2Rotate(*this, degrees);
+    inline Vector2 Rotate(float angle) const {
+        return Vector2Rotate(*this, angle);
     }
 
     /**


### PR DESCRIPTION
Corrects a small mistake in the comments and in the parameter name, which indicated degrees instead of radian.

`Vector2Rotate()` takes radians ([source](https://github.com/raysan5/raylib/blob/master/src/raymath.h#L435)):
```c
// Rotate vector by angle
RMAPI Vector2 Vector2Rotate(Vector2 v, float angle)
{
    Vector2 result = { 0 };

    float cosres = cosf(angle);
    float sinres = sinf(angle);

    result.x = v.x*cosres - v.y*sinres;
    result.y = v.x*sinres + v.y*cosres;

    return result;
}
```