### PR TITLE
Fix Window::SetExitKey() method return type

### DIFF
--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -79,8 +79,8 @@ class Window {
     /**
      * Set a custom key to exit program (default is ESC)
      */
-    bool SetExitKey(int key) {
-        return ::SetExitKey(key);
+    void SetExitKey(int key) {
+        ::SetExitKey(key);
     }
 
     /**


### PR DESCRIPTION
Just noticed this silly mistake - fixed. 