### PR TITLE
added Keyboard to cmake install

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -16,6 +16,7 @@ install(FILES
     Functions.hpp
     Gamepad.hpp
     Image.hpp
+    Keyboard.hpp
     Material.hpp
     Matrix.hpp
     Mesh.hpp


### PR DESCRIPTION
When trying to build a project, it fails because of the missing header file `Keyboard.hpp`.