### PR TITLE
Update Test.yml to newer version

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -22,8 +22,8 @@ jobs:
         platform:
         # - { name: Windows VS2019, os: windows-2019 }
         # - { name: Windows VS2022, os: windows-2022 }
-        - { name: Linux GCC,      os: ubuntu-20.04, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=17 }
-        - { name: Linux Clang,    os: ubuntu-20.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=17 }
+        - { name: Linux GCC,      os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=17 }
+        - { name: Linux Clang,    os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=17 }
         #- { name: Linux GCC,      os: ubuntu-18.04, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=14 }
         #- { name: Linux Clang,    os: ubuntu-18.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=14 }
         # - { name: MacOS XCode,    os: macos-latest }

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -35,7 +35,7 @@ jobs:
         - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug }
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Install Linux Dependencies


### PR DESCRIPTION
The build system used ubuntu 20.04, but the latest LTS is 22.04, so I updated the version.
The build system used checkout version 2, which will be depricated soon, so I updated it as well.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 