### PR TITLE
AudioStream: Only Unload() if it's ready

### DIFF
--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -90,7 +90,9 @@ class AudioStream : public ::AudioStream {
      * Unload audio stream and free memory
      */
     void Unload() {
-        ::UnloadAudioStream(*this);
+        if (IsReady()) {
+            ::UnloadAudioStream(*this);
+        }
     }
 
     /**


### PR DESCRIPTION
@akiriwas How is this? This will only call UnloadAudioStream() if the audio stream actually exists.

Fixes #290
