### PR TITLE
Use namespaces for Keyboard/Mouse/Touch

### DIFF
--- a/include/Keyboard.hpp
+++ b/include/Keyboard.hpp
@@ -7,8 +7,7 @@ namespace raylib {
 /**
  * Input-related functions: keyboard
  */
-class Keyboard {
- public:
+namespace Keyboard {
     /**
      * Detect if a key has been pressed once
      */
@@ -60,6 +59,6 @@ class Keyboard {
 };
 } // namespace raylib
 
-using RKeyboard = raylib::Keyboard;
+namespace RKeyboard = raylib::Keyboard;
 
 #endif // RAYLIB_CPP_INCLUDE_KEYBOARD_HPP_

--- a/include/Keyboard.hpp
+++ b/include/Keyboard.hpp
@@ -11,49 +11,49 @@ namespace Keyboard {
     /**
      * Detect if a key has been pressed once
      */
-    static bool IsKeyPressed(int key) {
+    [[maybe_unused]] RLCPPAPI inline bool IsKeyPressed(int key) {
         return ::IsKeyPressed(key);
     }
 
     /**
      * Detect if a key has been pressed again (Only PLATFORM_DESKTOP)
      */
-    static bool IsKeyPressedRepeat(int key) {
+    [[maybe_unused]] RLCPPAPI inline bool IsKeyPressedRepeat(int key) {
         return ::IsKeyPressedRepeat(key);
     }
 
     /**
      * Detect if a key is being pressed
      */
-    static bool IsKeyDown(int key) {
+    [[maybe_unused]] RLCPPAPI inline bool IsKeyDown(int key) {
         return ::IsKeyDown(key);
     }
 
     /**
      * Detect if a key has been released once
      */
-    static bool IsKeyReleased(int key) {
+    [[maybe_unused]] RLCPPAPI inline bool IsKeyReleased(int key) {
         return ::IsKeyReleased(key);
     }
 
     /**
      * Detect if a key is NOT being pressed
      */
-    static bool IsKeyUp(int key) {
+    [[maybe_unused]] RLCPPAPI inline bool IsKeyUp(int key) {
         return ::IsKeyUp(key);
     }
 
     /**
      * Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
      */
-    static bool GetKeyPressed() {
+    [[maybe_unused]] RLCPPAPI inline bool GetKeyPressed() {
         return ::GetKeyPressed();
     }
 
     /**
      * Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
      */
-    static bool GetCharPressed() {
+    [[maybe_unused]] RLCPPAPI inline bool GetCharPressed() {
         return ::GetCharPressed();
     }
 };

--- a/include/Mouse.hpp
+++ b/include/Mouse.hpp
@@ -12,83 +12,83 @@ namespace Mouse {
     /**
      * Detect if a mouse button has been pressed once
      */
-    static bool IsButtonPressed(int button) {
+    [[maybe_unused]] RLCPPAPI inline bool IsButtonPressed(int button) {
         return ::IsMouseButtonPressed(button);
     }
 
     /**
      * Detect if a mouse button is being pressed
      */
-    static bool IsButtonDown(int button) {
+    [[maybe_unused]] RLCPPAPI inline bool IsButtonDown(int button) {
         return ::IsMouseButtonDown(button);
     }
 
     /**
      * Detect if a mouse button has been released once
      */
-    static bool IsButtonReleased(int button) {
+    [[maybe_unused]] RLCPPAPI inline bool IsButtonReleased(int button) {
         return ::IsMouseButtonReleased(button);
     }
 
-    static bool IsButtonUp(int button) {
+    [[maybe_unused]] RLCPPAPI inline bool IsButtonUp(int button) {
         return ::IsMouseButtonUp(button);
     }
 
-    static int GetX() {
+    [[maybe_unused]] RLCPPAPI inline int GetX() {
         return ::GetMouseX();
     }
 
-    static int GetY() {
+    [[maybe_unused]] RLCPPAPI inline int GetY() {
         return ::GetMouseY();
     }
 
-    static void SetX(int x) {
+    [[maybe_unused]] RLCPPAPI inline void SetX(int x) {
         ::SetMousePosition(x, GetY());
     }
 
-    static void SetY(int y) {
+    [[maybe_unused]] RLCPPAPI inline void SetY(int y) {
         ::SetMousePosition(GetX(), y);
     }
 
-    static Vector2 GetPosition() {
+    [[maybe_unused]] RLCPPAPI inline Vector2 GetPosition() {
         return ::GetMousePosition();
     }
 
-    static void SetPosition(int x, int y) {
+    [[maybe_unused]] RLCPPAPI inline void SetPosition(int x, int y) {
         ::SetMousePosition(x, y);
     }
 
-    static void SetPosition(::Vector2 position) {
+    [[maybe_unused]] RLCPPAPI inline void SetPosition(::Vector2 position) {
         ::SetMousePosition(static_cast<int>(position.x), static_cast<int>(position.y));
     }
 
     /**
      * Get mouse delta between frames
      */
-    static Vector2 GetDelta() {
+    [[maybe_unused]] RLCPPAPI inline Vector2 GetDelta() {
         return ::GetMouseDelta();
     }
 
-    static void SetOffset(int offsetX = 0, int offsetY = 0) {
+    [[maybe_unused]] RLCPPAPI inline void SetOffset(int offsetX = 0, int offsetY = 0) {
         ::SetMouseOffset(offsetX, offsetY);
     }
 
-    static void SetOffset(::Vector2 offset) {
+    [[maybe_unused]] RLCPPAPI inline void SetOffset(::Vector2 offset) {
         ::SetMouseOffset(static_cast<int>(offset.x), static_cast<int>(offset.y));
     }
 
-    static void SetScale(float scaleX = 1.0f, float scaleY = 1.0f) {
+    [[maybe_unused]] RLCPPAPI inline void SetScale(float scaleX = 1.0f, float scaleY = 1.0f) {
         ::SetMouseScale(scaleX, scaleY);
     }
 
-    static void SetScale(::Vector2 scale) {
+    [[maybe_unused]] RLCPPAPI inline void SetScale(::Vector2 scale) {
         ::SetMouseScale(scale.x, scale.y);
     }
 
     /**
      * Get mouse wheel movement for X or Y, whichever is larger
      */
-    static float GetWheelMove() {
+    [[maybe_unused]] RLCPPAPI inline float GetWheelMove() {
         return ::GetMouseWheelMove();
     }
 
@@ -97,7 +97,7 @@ namespace Mouse {
      *
      * @see ::GetMouseWheelMoveV()
      */
-    static Vector2 GetWheelMoveV() {
+    [[maybe_unused]] RLCPPAPI inline Vector2 GetWheelMoveV() {
         return GetMouseWheelMoveV();
     }
 
@@ -106,42 +106,42 @@ namespace Mouse {
      *
      * @see ::MouseCursor
      */
-    static void SetCursor(int cursor = MOUSE_CURSOR_DEFAULT) {
+    [[maybe_unused]] RLCPPAPI inline void SetCursor(int cursor = MOUSE_CURSOR_DEFAULT) {
         ::SetMouseCursor(cursor);
     }
 
     /**
      * Get touch position X for touch point 0 (relative to screen size)
      */
-    static int GetTouchX() {
+    [[maybe_unused]] RLCPPAPI inline int GetTouchX() {
         return ::GetTouchX();
     }
 
     /**
      * Get touch position Y for touch point 0 (relative to screen size)
      */
-    static int GetTouchY() {
+    [[maybe_unused]] RLCPPAPI inline int GetTouchY() {
         return ::GetTouchY();
     }
 
     /**
      * Get touch position XY for a touch point index (relative to screen size)
      */
-    static Vector2 GetTouchPosition(int index) {
+    [[maybe_unused]] RLCPPAPI inline Vector2 GetTouchPosition(int index) {
         return ::GetTouchPosition(index);
     }
 
     /**
      * Get a ray trace from mouse position
      */
-    static Ray GetRay(::Vector2 mousePosition, const ::Camera& camera) {
+    [[maybe_unused]] RLCPPAPI inline Ray GetRay(::Vector2 mousePosition, const ::Camera& camera) {
         return ::GetMouseRay(mousePosition, camera);
     }
 
     /**
      * Get a ray trace from mouse position
      */
-    static Ray GetRay(const ::Camera& camera) {
+    [[maybe_unused]] RLCPPAPI inline Ray GetRay(const ::Camera& camera) {
         return ::GetMouseRay(::GetMousePosition(), camera);
     }
 };

--- a/include/Mouse.hpp
+++ b/include/Mouse.hpp
@@ -8,8 +8,7 @@ namespace raylib {
 /**
  * Input-related functions: mouse
  */
-class Mouse {
- public:
+namespace Mouse {
     /**
      * Detect if a mouse button has been pressed once
      */
@@ -148,6 +147,6 @@ class Mouse {
 };
 }  // namespace raylib
 
-using RMouse = raylib::Mouse;
+namespace RMouse = raylib::Mouse;
 
 #endif  // RAYLIB_CPP_INCLUDE_MOUSE_HPP_

--- a/include/Touch.hpp
+++ b/include/Touch.hpp
@@ -7,45 +7,44 @@ namespace raylib {
 /**
  * Input-related functions: touch
  */
-class Touch {
- public:
+namespace Touch {
     /**
      * Get touch position X for touch point 0 (relative to screen size)
      */
-    static int GetX() {
+    [[maybe_unused]] RLCPPAPI inline int GetX() {
         return ::GetTouchX();
     }
 
     /**
      * Get touch position Y for touch point 0 (relative to screen size)
      */
-    static int GetY() {
+    [[maybe_unused]] RLCPPAPI inline int GetY() {
         return ::GetTouchY();
     }
 
     /**
      * Get touch position XY for a touch point index (relative to screen size)
      */
-    static Vector2 GetPosition(int index) {
+    [[maybe_unused]] RLCPPAPI inline Vector2 GetPosition(int index) {
         return ::GetTouchPosition(index);
     }
 
     /**
      * Get touch point identifier for given index
      */
-    static int GetPointId(int index) {
+    [[maybe_unused]] RLCPPAPI inline int GetPointId(int index) {
         return ::GetTouchPointId(index);
     }
 
     /**
      * Get number of touch points
      */
-    static int GetPointCount() {
+    [[maybe_unused]] RLCPPAPI inline int GetPointCount() {
         return ::GetTouchPointCount();
     }
 };
 }  // namespace raylib
 
-using RTouch = raylib::Touch;
+namespace RTouch = raylib::Touch;
 
 #endif  // RAYLIB_CPP_INCLUDE_TOUCH_HPP_


### PR DESCRIPTION
This makes the Keyboard, Mouse, and Touch use namespaces instead of a class. Fixes #289
