### PR TITLE
Remove new in throw

### DIFF
--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -166,7 +166,7 @@ class Font : public ::Font {
     void Load(const std::string& fileName) {
         set(::LoadFont(fileName.c_str()));
         if (!IsReady()) {
-            throw new RaylibException("Failed to load Font with from file: " + fileName);
+            throw RaylibException("Failed to load Font with from file: " + fileName);
         }
     }
 
@@ -183,14 +183,14 @@ class Font : public ::Font {
     void Load(const std::string& fileName, int fontSize, int* fontChars, int charCount)  {
         set(::LoadFontEx(fileName.c_str(), fontSize, fontChars, charCount));
         if (!IsReady()) {
-            throw new RaylibException("Failed to load Font with from file with font size: " + fileName);
+            throw RaylibException("Failed to load Font with from file with font size: " + fileName);
         }
     }
 
     void Load(const ::Image& image, ::Color key, int firstChar) {
         set(::LoadFontFromImage(image, key, firstChar));
         if (!IsReady()) {
-            throw new RaylibException("Failed to load Font with from image");
+            throw RaylibException("Failed to load Font with from image");
         }
     }
 
@@ -199,7 +199,7 @@ class Font : public ::Font {
         set(::LoadFontFromMemory(fileType.c_str(), fileData, dataSize, fontSize, fontChars,
             charsCount));
         if (!IsReady()) {
-            throw new RaylibException("Failed to load Font " + fileType + " with from file data");
+            throw RaylibException("Failed to load Font " + fileType + " with from file data");
         }
     }
 

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -216,7 +216,7 @@ class Mesh : public ::Mesh {
      */
     void Export(const std::string& fileName) {
         if (!::ExportMesh(*this, fileName.c_str())) {
-            throw new RaylibException("Failed to export the Mesh");
+            throw RaylibException("Failed to export the Mesh");
         }
     }
 

--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -173,7 +173,7 @@ class Sound : public ::Sound {
     void Load(const std::string& fileName) {
         set(::LoadSound(fileName.c_str()));
         if (!IsReady()) {
-            throw new RaylibException("Failed to load Sound from file");
+            throw RaylibException("Failed to load Sound from file");
         }
     }
 
@@ -185,7 +185,7 @@ class Sound : public ::Sound {
     void Load(const ::Wave& wave) {
         set(::LoadSoundFromWave(wave));
         if (!IsReady()) {
-            throw new RaylibException("Failed to load Wave");
+            throw RaylibException("Failed to load Wave");
         }
     }
 


### PR DESCRIPTION
Potential memory leak. 
Always throw as value and catch as const-ref. - https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#e15-throw-by-value-catch-exceptions-from-a-hierarchy-by-reference