### PR TITLE
Replace typedef with using

### DIFF
--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -129,7 +129,7 @@ class Camera3D : public ::Camera3D {
     }
 };
 
-typedef Camera3D Camera;
+using Camera = Camera3D;
 
 }  // namespace raylib
 

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -134,7 +134,9 @@ class RenderTexture : public ::RenderTexture {
         depth = renderTexture.depth;
     }
 };
-typedef RenderTexture RenderTexture2D;
+
+using RenderTexture2D = RenderTexture;
+
 }  // namespace raylib
 
 using RRenderTexture = raylib::RenderTexture;

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -67,8 +67,8 @@ class Texture : public TextureUnmanaged {
 };
 
 // Create the Texture aliases.
-typedef Texture Texture2D;
-typedef Texture TextureCubemap;
+using Texture2D = Texture;
+using TextureCubemap = Texture;
 
 }  // namespace raylib
 

--- a/include/TextureUnmanaged.hpp
+++ b/include/TextureUnmanaged.hpp
@@ -334,8 +334,8 @@ class TextureUnmanaged : public ::Texture {
 };
 
 // Create the TextureUnmanaged aliases.
-typedef TextureUnmanaged Texture2DUnmanaged;
-typedef TextureUnmanaged TextureCubemapUnmanaged;
+using Texture2DUnmanaged = TextureUnmanaged;
+using TextureCubemapUnmanaged = TextureUnmanaged;
 
 }  // namespace raylib
 

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -171,7 +171,8 @@ class Vector4 : public ::Vector4 {
 };
 
 // Alias the Vector4 as Quaternion.
-typedef Vector4 Quaternion;
+using Quaternion = Vector4;
+
 }  // namespace raylib
 
 using RVector4 = raylib::Vector4;


### PR DESCRIPTION
[Prefer using over typedef for defining aliases](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#t43-prefer-using-over-typedef-for-defining-aliases)