### PR TITLE
Add overload for `DrawRoundedLines`

### DIFF
--- a/include/Rectangle.hpp
+++ b/include/Rectangle.hpp
@@ -80,9 +80,13 @@ class Rectangle : public ::Rectangle {
         ::DrawRectangleRounded(*this, roundness, segments, color);
     }
 
+    void DrawRoundedLines(float roundness, int segments, ::Color color) const {
+        ::DrawRectangleRoundedLines(*this, roundness, segments, color);
+    }
+
     void DrawRoundedLines(float roundness, int segments,
             float lineThick, ::Color color) const {
-        ::DrawRectangleRoundedLines(*this, roundness, segments, lineThick, color);
+        ::DrawRectangleRoundedLinesEx(*this, roundness, segments, lineThick, color);
     }
 
     /**


### PR DESCRIPTION
An error occurred during compilation for both the raylib master branch (https://github.com/raysan5/raylib/commit/f1007554a0a8145060797c0aa8169bdaf2c1c6b8) and the raylib-cpp master branch (https://github.com/RobLoach/raylib-cpp/commit/c8a910ef2e2c60651d3381dd9e6a2b14e64b7ee4). I noticed that the `::DrawRectangleRoundedLines` function no longer accepts the `lineThick` parameter.

It appears that this parameter has been removed to be added as a new "overload" `::DrawRectangleRoundedLinesEx`.

Therefore, I've also added this overload to raylib-cpp. One overload doesn't take `lineThick` to call `::DrawRectangleRoundedLines`, and the other takes `lineThick` to call `::DrawRectangleRoundedLinesEx`.

Link to this new function: [rshapes.c#L1097](https://github.com/raysan5/raylib/blob/master/src/rshapes.c#L1097)