### PR TITLE
Add copy name in ModelAnimation

### DIFF
--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+#include <cstring>
 
 #include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
@@ -102,6 +103,7 @@ class ModelAnimation : public ::ModelAnimation {
         frameCount = model.frameCount;
         bones = model.bones;
         framePoses = model.framePoses;
+        std::strcpy(name, model.name);
     }
 };
 }  // namespace raylib


### PR DESCRIPTION
The name property was missing from the ModelAnimation set method.