### PR TITLE
Add Code Formatting (#331)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,163 @@
+---
+Language:        Cpp
+BasedOnStyle:    Google
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AllowAllArgumentsOnNextLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: true
+## @TODO: when update to clang-format 19, use BreakTemplateDeclarations
+#BreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      true
+  BeforeLambdaBody: true
+  BeforeWhile:     true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeConceptDeclarations: false
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 120
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineBeforeAccessModifier: Never
+EmptyLineAfterAccessModifier: Never
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+PPIndentWidth:   2
+QualifierAlignment: Leave
+ReferenceAlignment: Left
+ReflowComments: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros:  false
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:       false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 4
+LineEnding: LF
+UseTab: Never
+CommentPragmas: "\/*(.*)*\/"
+PackConstructorInitializers: CurrentLine
+FixNamespaceComments: true
+# Include settings
+IncludeBlocks: Preserve
+IncludeCategories:
+  # Main Module Header automatically gets a priority of 0
+  # Local/Private Headers
+  - Regex: '^"[^\/"]*"$'
+    Priority: 200
+    # Project/subproject headers
+  - Regex: '^"[^"]*"$'
+    Priority: 300
+    # standard library headers
+  - Regex: '^<[^>\.\/]+>$'
+    Priority: 500
+    # standard library headers - experimental
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 550
+  - Regex: '^<experimental[^>\.]+>$'
+    Priority: 600
+    # third party libraries
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 450
+  - Regex: '^<[^>]+>$'
+    Priority: 400
+    # Everything that didn't match
+  - Regex: '.*'
+    Priority: 1000
+IncludeIsMainRegex: (Test)?$
+SortIncludes: CaseSensitive
+# Custom style rules
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+Standard: c++20
+---
+Language: JavaScript
+IndentWidth: 2
+ColumnLimit: 100

--- a/.clang-format
+++ b/.clang-format
@@ -156,7 +156,7 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-Standard: c++20
+Standard: c++11
 ---
 Language: JavaScript
 IndentWidth: 2

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,94 @@
+---
+Checks: "*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-linuxkernel*,-llvm*,-android-*,
+                  -modernize-use-trailing-return-type,
+                  -readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-readability-else-after-return,
+                  -readability-static-accessed-through-instance,
+                  -readability-avoid-const-params-in-decls,
+                  -cppcoreguidelines-non-private-member-variables-in-classes,
+                  -misc-non-private-member-variables-in-classes,
+                  -altera-struct-pack-align,
+                  -altera-unroll-loops,
+                  -altera-id-dependent-backward-branch,
+                  -readability-identifier-length,
+                  readability-identifier-naming,
+                  llvm-include-order,
+                  -llvm-header-guard,
+                  bugprone-*,
+                  cert-*,
+                  modernize-*
+                  -modernize-use-trailing-return-type,
+                  -readability-else-after-return,
+                  -readability-static-accessed-through-instance,
+                  -readability-avoid-const-params-in-decls,
+                  -readability-uppercase-literal-suffix,
+                  -cppcoreguidelines-non-private-member-variables-in-classes,
+                  -misc-non-private-member-variables-in-classes,
+                  *-uppercase-literal-suffix,
+"
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: file
+
+CheckOptions:
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.ScopedEnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.ProtectedMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.PublicMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstexprMethodCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassMethodCase
+    value: CamelCase
+  - key: readability-identifier-naming.PublicMethodCase
+    value: CamelCase
+  - key: readability-identifier-naming.PrivateMethodCase
+    value: CamelCase
+  - key: readability-identifier-naming.ProtectedMethodCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstexprMethodCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+  - key: readability-identifier-naming.LocalVariableCase
+    value: camelBack
+  - key: readability-identifier-naming.ConstantParameterCase
+    value: camelBack
+  - key: readability-identifier-naming.ParameterPackCase
+    value: camelBack
+  - key: readability-identifier-naming.LocalConstantCase
+    value: camelBack
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key: readability-identifier-naming.TemplateParameterCase
+    value: CamelCase
+  - key: readability-identifier-naming.TemplateTemplateParameterCase
+    value: CamelCase
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: 'm_'
+  - key: readability-identifier-length.IgnoredVariableNames
+    value: 'i|j|k|x|y|z'
+  - key: readability-identifier-length.IgnoredParameterNames
+    value: 'i|j|k|x|y|z'

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,219 @@
+_help_parse: Options affecting listfile parsing
+parse:
+  _help_additional_commands:
+    - Specify structure for custom cmake functions
+  additional_commands:
+    foo:
+      flags:
+        - BAR
+        - BAZ
+      kwargs:
+        HEADERS: '*'
+        SOURCES: '*'
+        DEPENDS: '*'
+  _help_vartags:
+    - Specify variable tags.
+  vartags: []
+  _help_proptags:
+    - Specify property tags.
+  proptags: []
+_help_format: Options affecting formatting.
+format:
+  _help_line_width:
+    - How wide to allow formatted cmake files
+  line_width: 140
+  _help_tab_size:
+    - How many spaces to tab for indent
+  tab_size: 2
+  _help_max_subgroups_hwrap:
+    - If an argument group contains more than this many sub-groups
+    - (parg or kwarg groups) then force it to a vertical layout.
+  max_subgroups_hwrap: 2
+  _help_max_pargs_hwrap:
+    - If a positional argument group contains more than this many
+    - arguments, then force it to a vertical layout.
+  max_pargs_hwrap: 6
+  _help_max_rows_cmdline:
+    - If a cmdline positional group consumes more than this many
+    - lines without nesting, then invalidate the layout (and nest)
+  max_rows_cmdline: 2
+  _help_separate_ctrl_name_with_space:
+    - If true, separate flow control names from their parentheses
+    - with a space
+  separate_ctrl_name_with_space: false
+  _help_separate_fn_name_with_space:
+    - If true, separate function names from parentheses with a
+    - space
+  separate_fn_name_with_space: false
+  _help_dangle_parens:
+    - If a statement is wrapped to more than one line, than dangle
+    - the closing parenthesis on its own line.
+  dangle_parens: false
+  _help_dangle_align:
+    - If the trailing parenthesis must be 'dangled' on its on
+    - 'line, then align it to this reference: `prefix`: the start'
+    - 'of the statement,  `prefix-indent`: the start of the'
+    - 'statement, plus one indentation  level, `child`: align to'
+    - the column of the arguments
+  dangle_align: prefix
+  _help_min_prefix_chars:
+    - If the statement spelling length (including space and
+    - parenthesis) is smaller than this amount, then force reject
+    - nested layouts.
+  min_prefix_chars: 4
+  _help_max_prefix_chars:
+    - If the statement spelling length (including space and
+    - parenthesis) is larger than the tab width by more than this
+    - amount, then force reject un-nested layouts.
+  max_prefix_chars: 10
+  _help_max_lines_hwrap:
+    - If a candidate layout is wrapped horizontally but it exceeds
+    - this many lines, then reject the layout.
+  max_lines_hwrap: 2
+  _help_line_ending:
+    - What style line endings to use in the output.
+  line_ending: unix
+  _help_command_case:
+    - Format command names consistently as 'lower' or 'upper' case
+  command_case: canonical
+  _help_keyword_case:
+    - Format keywords consistently as 'lower' or 'upper' case
+  keyword_case: unchanged
+  _help_always_wrap:
+    - A list of command names which should always be wrapped
+  always_wrap: []
+  _help_enable_sort:
+    - If true, the argument lists which are known to be sortable
+    - will be sorted lexicographicall
+  enable_sort: true
+  _help_autosort:
+    - If true, the parsers may infer whether or not an argument
+    - list is sortable (without annotation).
+  autosort: false
+  _help_require_valid_layout:
+    - By default, if cmake-format cannot successfully fit
+    - everything into the desired linewidth it will apply the
+    - last, most agressive attempt that it made. If this flag is
+    - True, however, cmake-format will print error, exit with non-
+    - zero status code, and write-out nothing
+  require_valid_layout: false
+  _help_layout_passes:
+    - A dictionary mapping layout nodes to a list of wrap
+    - decisions. See the documentation for more information.
+  layout_passes: {}
+_help_markup: Options affecting comment reflow and formatting.
+markup:
+  _help_bullet_char:
+    - What character to use for bulleted lists
+  bullet_char: '*'
+  _help_enum_char:
+    - What character to use as punctuation after numerals in an
+    - enumerated list
+  enum_char: .
+  _help_first_comment_is_literal:
+    - If comment markup is enabled, don't reflow the first comment
+    - block in each listfile. Use this to preserve formatting of
+    - your copyright/license statements.
+  first_comment_is_literal: false
+  _help_literal_comment_pattern:
+    - If comment markup is enabled, don't reflow any comment block
+    - which matches this (regex) pattern. Default is `None`
+    - (disabled).
+  literal_comment_pattern: null
+  _help_fence_pattern:
+    - Regular expression to match preformat fences in comments
+    - default= ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+  fence_pattern: ^\s*([`~]{3}[`~]*)(.*)$
+  _help_ruler_pattern:
+    - Regular expression to match rulers in comments default=
+    - '``r''^\s*[^\w\s]{3}.*[^\w\s]{3}$''``'
+  ruler_pattern: ^\s*[^\w\s]{3}.*[^\w\s]{3}$
+  _help_explicit_trailing_pattern:
+    - If a comment line matches starts with this pattern then it
+    - is explicitly a trailing comment for the preceeding
+    - argument. Default is '#<'
+  explicit_trailing_pattern: '#<'
+  _help_hashruler_min_length:
+    - If a comment line starts with at least this many consecutive
+    - hash characters, then don't lstrip() them off. This allows
+    - for lazy hash rulers where the first hash char is not
+    - separated by space
+  hashruler_min_length: 10
+  _help_canonicalize_hashrulers:
+    - If true, then insert a space between the first hash char and
+    - remaining hash chars in a hash ruler, and normalize its
+    - length to fill the column
+  canonicalize_hashrulers: true
+  _help_enable_markup:
+    - enable comment markup parsing and reflow
+  enable_markup: true
+_help_lint: Options affecting the linter
+lint:
+  _help_disabled_codes:
+    - a list of lint codes to disable
+  disabled_codes: []
+  _help_function_pattern:
+    - regular expression pattern describing valid function names
+  function_pattern: '[0-9a-z_]+'
+  _help_macro_pattern:
+    - regular expression pattern describing valid macro names
+  macro_pattern: '[0-9A-Z_]+'
+  _help_global_var_pattern:
+    - regular expression pattern describing valid names for
+    - variables with global scope
+  global_var_pattern: '[0-9A-Z][0-9A-Z_]+'
+  _help_internal_var_pattern:
+    - regular expression pattern describing valid names for
+    - variables with global scope (but internal semantic)
+  internal_var_pattern: _[0-9A-Z][0-9A-Z_]+
+  _help_local_var_pattern:
+    - regular expression pattern describing valid names for
+    - variables with local scope
+  local_var_pattern: '[0-9a-z_]+'
+  _help_private_var_pattern:
+    - regular expression pattern describing valid names for
+    - privatedirectory variables
+  private_var_pattern: _[0-9a-z_]+
+  _help_public_var_pattern:
+    - regular expression pattern describing valid names for
+    - publicdirectory variables
+  public_var_pattern: '[0-9A-Z][0-9A-Z_]+'
+  _help_keyword_pattern:
+    - regular expression pattern describing valid names for
+    - keywords used in functions or macros
+  keyword_pattern: '[0-9A-Z_]+'
+  _help_max_conditionals_custom_parser:
+    - In the heuristic for C0201, how many conditionals to match
+    - within a loop in before considering the loop a parser.
+  max_conditionals_custom_parser: 2
+  _help_min_statement_spacing:
+    - Require at least this many newlines between statements
+  min_statement_spacing: 1
+  _help_max_statement_spacing:
+    - Require no more than this many newlines between statements
+  max_statement_spacing: 1
+  max_returns: 6
+  max_branches: 12
+  max_arguments: 5
+  max_localvars: 15
+  max_statements: 50
+_help_encode: Options affecting file encoding
+encode:
+  _help_emit_byteorder_mark:
+    - If true, emit the unicode byte-order mark (BOM) at the start
+    - of the file
+  emit_byteorder_mark: false
+  _help_input_encoding:
+    - Specify the encoding of the input file. Defaults to utf-8
+  input_encoding: utf-8
+  _help_output_encoding:
+    - Specify the encoding of the output file. Defaults to utf-8.
+    - Note that cmake only claims to support utf-8 so be careful
+    - when using anything else
+  output_encoding: utf-8
+_help_misc: Miscellaneous configurations options.
+misc:
+  _help_per_command:
+    - A dictionary containing any per-command configuration
+    - overrides. Currently only `command_case` is supported.
+  per_command: {}

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,4 +32,13 @@ if(BUILD_RAYLIB_CPP_EXAMPLES)
         )
         add_subdirectory(tests)
     endif()
+
+    if (RAYLIB_CPP_IS_MAIN)
+        # @TODO: add examples files
+        add_custom_target(format-tests
+                COMMAND clang-format
+                -i
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/raylib_cpp_test.cpp
+        )
+    endif()
 endif()

--- a/include/AudioDevice.hpp
+++ b/include/AudioDevice.hpp
@@ -1,16 +1,16 @@
 #ifndef RAYLIB_CPP_INCLUDE_AUDIODEVICE_HPP_
 #define RAYLIB_CPP_INCLUDE_AUDIODEVICE_HPP_
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Audio device management functions.
  */
 class AudioDevice {
- public:
+public:
     /**
      * Initialize audio device and context.
      *
@@ -27,9 +27,7 @@ class AudioDevice {
     /**
      * Close the audio device and context.
      */
-    ~AudioDevice() {
-        Close();
-    }
+    ~AudioDevice() { Close(); }
 
     /**
      * Initialize audio device and context.
@@ -46,16 +44,12 @@ class AudioDevice {
     /**
      * Close the audio device and context.
      */
-    void Close() {
-        ::CloseAudioDevice();
-    }
+    void Close() { ::CloseAudioDevice(); }
 
     /**
      * Check if audio device has been initialized successfully.
      */
-    bool IsReady() const {
-        return ::IsAudioDeviceReady();
-    }
+    bool IsReady() const { return ::IsAudioDeviceReady(); }
 
     /**
      * Set master volume (listener).
@@ -67,8 +61,8 @@ class AudioDevice {
         return *this;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RAudioDevice = raylib::AudioDevice;
 
-#endif  // RAYLIB_CPP_INCLUDE_AUDIODEVICE_HPP_
+#endif // RAYLIB_CPP_INCLUDE_AUDIODEVICE_HPP_

--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -1,25 +1,25 @@
 #ifndef RAYLIB_CPP_INCLUDE_AUDIOSTREAM_HPP_
 #define RAYLIB_CPP_INCLUDE_AUDIOSTREAM_HPP_
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * AudioStream management functions
  */
 class AudioStream : public ::AudioStream {
- public:
-    AudioStream(const ::AudioStream& music) {
-        set(music);
-    }
+public:
+    AudioStream(const ::AudioStream& music) { set(music); }
 
-    AudioStream(rAudioBuffer* buffer = nullptr,
-            rAudioProcessor *processor = nullptr,
-            unsigned int sampleRate = 0,
-            unsigned int sampleSize = 0,
-            unsigned int channels = 0) : ::AudioStream{buffer, processor, sampleRate, sampleSize, channels} {
+    AudioStream(
+        rAudioBuffer* buffer = nullptr,
+        rAudioProcessor* processor = nullptr,
+        unsigned int sampleRate = 0,
+        unsigned int sampleSize = 0,
+        unsigned int channels = 0)
+        : ::AudioStream{buffer, processor, sampleRate, sampleSize, channels} {
         // Nothing.
     }
 
@@ -44,12 +44,10 @@ class AudioStream : public ::AudioStream {
         other.channels = 0;
     }
 
-    ~AudioStream() {
-        Unload();
-    }
+    ~AudioStream() { Unload(); }
 
-    GETTER(rAudioBuffer *, Buffer, buffer)
-    GETTER(rAudioProcessor *, Processor, processor)
+    GETTER(rAudioBuffer*, Buffer, buffer)
+    GETTER(rAudioProcessor*, Processor, processor)
     GETTER(unsigned int, SampleRate, sampleRate)
     GETTER(unsigned int, SampleSize, sampleSize)
     GETTER(unsigned int, Channels, channels)
@@ -81,7 +79,7 @@ class AudioStream : public ::AudioStream {
     /**
      * Update audio stream buffers with data
      */
-    AudioStream& Update(const void *data, int samplesCount) {
+    AudioStream& Update(const void* data, int samplesCount) {
         ::UpdateAudioStream(*this, data, samplesCount);
         return *this;
     }
@@ -98,9 +96,7 @@ class AudioStream : public ::AudioStream {
     /**
      * Check if any audio stream buffers requires refill
      */
-    bool IsProcessed() const {
-        return ::IsAudioStreamProcessed(*this);
-    }
+    bool IsProcessed() const { return ::IsAudioStreamProcessed(*this); }
 
     /**
      * Play audio stream
@@ -129,9 +125,7 @@ class AudioStream : public ::AudioStream {
     /**
      * Check if audio stream is playing
      */
-    bool IsPlaying() const {
-        return ::IsAudioStreamPlaying(*this);
-    }
+    bool IsPlaying() const { return ::IsAudioStreamPlaying(*this); }
 
     /**
      * Stop audio stream
@@ -168,37 +162,27 @@ class AudioStream : public ::AudioStream {
     /**
      * Default size for new audio streams
      */
-    static void SetBufferSizeDefault(int size) {
-        ::SetAudioStreamBufferSizeDefault(size);
-    }
+    static void SetBufferSizeDefault(int size) { ::SetAudioStreamBufferSizeDefault(size); }
 
     /**
      * Audio thread callback to request new data
      */
-    void SetCallback(::AudioCallback callback) {
-        ::SetAudioStreamCallback(*this, callback);
-    }
+    void SetCallback(::AudioCallback callback) { ::SetAudioStreamCallback(*this, callback); }
 
     /**
      * Attach audio stream processor to stream
      */
-    void AttachProcessor(::AudioCallback processor) {
-        ::AttachAudioStreamProcessor(*this, processor);
-    }
+    void AttachProcessor(::AudioCallback processor) { ::AttachAudioStreamProcessor(*this, processor); }
 
     /**
      * Detach audio stream processor from stream
      */
-    void DetachProcessor(::AudioCallback processor) {
-        ::DetachAudioStreamProcessor(*this, processor);
-    }
+    void DetachProcessor(::AudioCallback processor) { ::DetachAudioStreamProcessor(*this, processor); }
 
     /**
      * Retrieve whether or not the audio stream is ready.
      */
-    bool IsReady() const {
-        return ::IsAudioStreamReady(*this);
-    }
+    bool IsReady() const { return ::IsAudioStreamReady(*this); }
 
     /**
      * Load audio stream (to stream raw audio pcm data)
@@ -212,8 +196,7 @@ class AudioStream : public ::AudioStream {
             throw RaylibException("Failed to load audio stream");
         }
     }
-
- protected:
+protected:
     void set(const ::AudioStream& stream) {
         buffer = stream.buffer;
         processor = stream.processor;
@@ -222,8 +205,8 @@ class AudioStream : public ::AudioStream {
         channels = stream.channels;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RAudioStream = raylib::AudioStream;
 
-#endif  // RAYLIB_CPP_INCLUDE_AUDIOSTREAM_HPP_
+#endif // RAYLIB_CPP_INCLUDE_AUDIOSTREAM_HPP_

--- a/include/AutomationEventList.hpp
+++ b/include/AutomationEventList.hpp
@@ -1,35 +1,29 @@
 #ifndef RAYLIB_CPP_INCLUDE_AUTOMATIONEVENTLIST_HPP_
 #define RAYLIB_CPP_INCLUDE_AUTOMATIONEVENTLIST_HPP_
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * AutomationEventList management functions
  */
 class AutomationEventList : public ::AutomationEventList {
- public:
-    AutomationEventList(const ::AutomationEventList& automationEventList) {
-        set(automationEventList);
-    }
+public:
+    AutomationEventList(const ::AutomationEventList& automationEventList) { set(automationEventList); }
 
     /**
      * Load an empty automation events list.
      */
-    AutomationEventList() {
-        set(::LoadAutomationEventList(0));
-    }
+    AutomationEventList() { set(::LoadAutomationEventList(0)); }
 
     /**
      * Load automation events list from file.
      *
      * @param fileName The file path to load the automation events list from.
      */
-    AutomationEventList(const char* fileName) {
-        Load(fileName);
-    }
+    AutomationEventList(const char* fileName) { Load(fileName); }
 
     AutomationEventList(const AutomationEventList&) = delete;
 
@@ -41,9 +35,7 @@ class AutomationEventList : public ::AutomationEventList {
         other.events = nullptr;
     }
 
-    ~AutomationEventList() {
-        Unload();
-    }
+    ~AutomationEventList() { Unload(); }
 
     GETTER(unsigned int, Capacity, capacity)
     GETTER(unsigned int, Count, count)
@@ -92,29 +84,23 @@ class AutomationEventList : public ::AutomationEventList {
             return;
         }
 
-        // The function signature of UnloadAutomationEventList() changes from raylib 5.0.
-        #if RAYLIB_VERSION_MAJOR == 5
-            #if RAYLIB_VERSION_MINOR == 0
-                ::UnloadAutomationEventList(this);
-            #elif RAYLIB_VERSION_MINOR >= 1
-                ::UnloadAutomationEventList(*this);
-            #endif
-        #else
-            ::UnloadAutomationEventList(*this);
-        #endif
+// The function signature of UnloadAutomationEventList() changes from raylib 5.0.
+#if RAYLIB_VERSION_MAJOR == 5
+#if RAYLIB_VERSION_MINOR == 0
+        ::UnloadAutomationEventList(this);
+#elif RAYLIB_VERSION_MINOR >= 1
+        ::UnloadAutomationEventList(*this);
+#endif
+#else
+        ::UnloadAutomationEventList(*this);
+#endif
     }
 
-    bool IsReady() {
-        return events != nullptr;
-    }
+    bool IsReady() { return events != nullptr; }
 
-    bool Export(const char* fileName) {
-        return ::ExportAutomationEventList(*this, fileName);
-    }
+    bool Export(const char* fileName) { return ::ExportAutomationEventList(*this, fileName); }
 
-    void Set() {
-        ::SetAutomationEventList(this);
-    }
+    void Set() { ::SetAutomationEventList(this); }
 
     void SetBaseFrame(int frame) {
         Set();
@@ -139,16 +125,15 @@ class AutomationEventList : public ::AutomationEventList {
         Set();
         ::PlayAutomationEvent(this->events[index]);
     }
-
- protected:
+protected:
     void set(const ::AutomationEventList& other) {
         capacity = other.capacity;
         count = other.count;
         events = other.events;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RAutomationEventList = raylib::AutomationEventList;
 
-#endif  // RAYLIB_CPP_INCLUDE_AUTOMATIONEVENTLIST_HPP_
+#endif // RAYLIB_CPP_INCLUDE_AUTOMATIONEVENTLIST_HPP_

--- a/include/BoundingBox.hpp
+++ b/include/BoundingBox.hpp
@@ -1,15 +1,15 @@
 #ifndef RAYLIB_CPP_INCLUDE_BOUNDINGBOX_HPP_
 #define RAYLIB_CPP_INCLUDE_BOUNDINGBOX_HPP_
 
-#include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Bounding box type
  */
 class BoundingBox : public ::BoundingBox {
- public:
+public:
     /*
      * Copy a bounding box from another bounding box.
      */
@@ -20,9 +20,7 @@ class BoundingBox : public ::BoundingBox {
     /**
      * Compute mesh bounding box limits
      */
-    BoundingBox(const ::Mesh& mesh) {
-        set(::GetMeshBoundingBox(mesh));
-    }
+    BoundingBox(const ::Mesh& mesh) { set(::GetMeshBoundingBox(mesh)); }
 
     BoundingBox(::Vector3 minMax = ::Vector3{0.0f, 0.0f, 0.0f}) : ::BoundingBox{minMax, minMax} {}
     BoundingBox(::Vector3 min, ::Vector3 max) : ::BoundingBox{min, max} {}
@@ -38,39 +36,28 @@ class BoundingBox : public ::BoundingBox {
     /**
      * Draw a bounding box with wires
      */
-    void Draw(::Color color = {255, 255, 255, 255}) const {
-        ::DrawBoundingBox(*this, color);
-    }
+    void Draw(::Color color = {255, 255, 255, 255}) const { ::DrawBoundingBox(*this, color); }
 
     /**
      * Detect collision between two boxes
      */
-    bool CheckCollision(const ::BoundingBox& box2) const {
-        return CheckCollisionBoxes(*this, box2);
-    }
+    bool CheckCollision(const ::BoundingBox& box2) const { return CheckCollisionBoxes(*this, box2); }
 
     /**
      * Detect collision between box and sphere
      */
-    bool CheckCollision(::Vector3 center, float radius) const {
-        return CheckCollisionBoxSphere(*this, center, radius);
-    }
+    bool CheckCollision(::Vector3 center, float radius) const { return CheckCollisionBoxSphere(*this, center, radius); }
 
     /**
      * Detect collision between ray and bounding box
      */
-    bool CheckCollision(const ::Ray& ray) const {
-        return GetRayCollisionBox(ray, *this).hit;
-    }
+    bool CheckCollision(const ::Ray& ray) const { return GetRayCollisionBox(ray, *this).hit; }
 
     /**
      * Get collision information between ray and bounding box
      */
-    RayCollision GetCollision(const ::Ray& ray) const {
-        return GetRayCollisionBox(ray, *this);
-    }
-
- protected:
+    RayCollision GetCollision(const ::Ray& ray) const { return GetRayCollisionBox(ray, *this); }
+protected:
     void set(const ::BoundingBox& box) {
         min = box.min;
         max = box.max;
@@ -80,8 +67,8 @@ class BoundingBox : public ::BoundingBox {
         max = _max;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RBoundingBox = raylib::BoundingBox;
 
-#endif  // RAYLIB_CPP_INCLUDE_BOUNDINGBOX_HPP_
+#endif // RAYLIB_CPP_INCLUDE_BOUNDINGBOX_HPP_

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,50 +1,50 @@
 add_library(raylib_cpp INTERFACE)
 
 set(RAYLIB_CPP_HEADERS
-  AudioDevice.hpp
-  AudioStream.hpp
-  AutomationEventList.hpp
-  BoundingBox.hpp
-  Camera2D.hpp
-  Camera3D.hpp
-  Color.hpp
-  FileData.hpp
-  FileText.hpp
-  Font.hpp
-  Functions.hpp
-  Gamepad.hpp
-  Image.hpp
-  Keyboard.hpp
-  Material.hpp
-  Matrix.hpp
-  Mesh.hpp
-  MeshUnmanaged.hpp
-  Model.hpp
-  ModelAnimation.hpp
-  Mouse.hpp
-  Music.hpp
-  Ray.hpp
-  RayCollision.hpp
-  RaylibException.hpp
-  raylib-cpp-utils.hpp
-  raylib-cpp.hpp
-  raylib.hpp
-  raymath.hpp
-  Rectangle.hpp
-  RenderTexture.hpp
-  ShaderUnmanaged.hpp
-  Shader.hpp
-  Sound.hpp
-  Text.hpp
-  Texture.hpp
-  TextureUnmanaged.hpp
-  Touch.hpp
-  Vector2.hpp
-  Vector3.hpp
-  Vector4.hpp
-  VrStereoConfig.hpp
-  Wave.hpp
-  Window.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/AudioDevice.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/AudioStream.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/AutomationEventList.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/BoundingBox.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Camera2D.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Camera3D.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Color.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/FileData.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/FileText.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Font.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Functions.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Gamepad.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Image.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Keyboard.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Material.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Matrix.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Mesh.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/MeshUnmanaged.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Model.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ModelAnimation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Mouse.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Music.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Ray.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RayCollision.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RaylibException.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/raylib-cpp-utils.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/raylib-cpp.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/raylib.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/raymath.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Rectangle.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RenderTexture.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ShaderUnmanaged.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Shader.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Sound.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Text.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Texture.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TextureUnmanaged.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Touch.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Vector2.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Vector3.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Vector4.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/VrStereoConfig.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Wave.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Window.hpp
 )
 
 # Include Directory
@@ -55,3 +55,12 @@ install(FILES
   ${RAYLIB_CPP_HEADERS}
   DESTINATION include
 )
+
+if (RAYLIB_CPP_IS_MAIN)
+    # @TODO: add examples files
+    add_custom_target(format
+            COMMAND clang-format
+            -i
+            ${RAYLIB_CPP_HEADERS}
+    )
+endif()

--- a/include/Camera2D.hpp
+++ b/include/Camera2D.hpp
@@ -1,23 +1,21 @@
 #ifndef RAYLIB_CPP_INCLUDE_CAMERA2D_HPP_
 #define RAYLIB_CPP_INCLUDE_CAMERA2D_HPP_
 
-#include "./raylib.hpp"
 #include "./Vector2.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Camera2D type, defines a 2d camera
  */
 class Camera2D : public ::Camera2D {
- public:
-    Camera2D(const ::Camera2D& camera) {
-        set(camera);
-    }
+public:
+    Camera2D(const ::Camera2D& camera) { set(camera); }
 
     Camera2D() {}
-    Camera2D(::Vector2 offset, ::Vector2 target,
-            float rotation = 0.0f, float zoom = 1.0f) : ::Camera2D{offset, target, rotation, zoom} {}
+    Camera2D(::Vector2 offset, ::Vector2 target, float rotation = 0.0f, float zoom = 1.0f)
+        : ::Camera2D{offset, target, rotation, zoom} {}
 
     Camera2D& BeginMode() {
         ::BeginMode2D(*this);
@@ -42,25 +40,18 @@ class Camera2D : public ::Camera2D {
     /**
      * Returns camera 2d transform matrix
      */
-    Matrix GetMatrix() const {
-        return ::GetCameraMatrix2D(*this);
-    }
+    Matrix GetMatrix() const { return ::GetCameraMatrix2D(*this); }
 
     /**
      * Returns the world space position for a 2d camera screen space position
      */
-    Vector2 GetScreenToWorld(::Vector2 position) const {
-        return ::GetScreenToWorld2D(position, *this);
-    }
+    Vector2 GetScreenToWorld(::Vector2 position) const { return ::GetScreenToWorld2D(position, *this); }
 
     /**
      * Returns the screen space position for a 3d world space position
      */
-    Vector2 GetWorldToScreen(::Vector2 position) const {
-        return ::GetWorldToScreen2D(position, *this);
-    }
-
- protected:
+    Vector2 GetWorldToScreen(::Vector2 position) const { return ::GetWorldToScreen2D(position, *this); }
+protected:
     void set(const ::Camera2D& camera) {
         offset = camera.offset;
         target = camera.target;
@@ -68,8 +59,8 @@ class Camera2D : public ::Camera2D {
         zoom = camera.zoom;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RCamera2D = raylib::Camera2D;
 
-#endif  // RAYLIB_CPP_INCLUDE_CAMERA2D_HPP_
+#endif // RAYLIB_CPP_INCLUDE_CAMERA2D_HPP_

--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -1,19 +1,17 @@
 #ifndef RAYLIB_CPP_INCLUDE_CAMERA3D_HPP_
 #define RAYLIB_CPP_INCLUDE_CAMERA3D_HPP_
 
-#include "./raylib.hpp"
 #include "./Vector3.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Camera type, defines a camera position/orientation in 3d space
  */
 class Camera3D : public ::Camera3D {
- public:
-    Camera3D(const ::Camera3D& camera) {
-        set(camera);
-    }
+public:
+    Camera3D(const ::Camera3D& camera) { set(camera); }
 
     /**
      * Create a new Camera3D.
@@ -21,14 +19,17 @@ class Camera3D : public ::Camera3D {
      * @param position Camera position
      * @param target Camera target it looks-at
      * @param up Camera up vector (rotation over its axis)
-     * @param fovy Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic
+     * @param fovy Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in
+     * orthographic
      * @param projection Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
      */
-    Camera3D(::Vector3 position,
-            ::Vector3 target = ::Vector3{0.0f, 0.0f, 0.0f},
-            ::Vector3 up = ::Vector3{0.0f, 1.0f, 0.0f},
-            float fovy = 0,
-            int projection = CAMERA_PERSPECTIVE) : ::Camera3D{position, target, up, fovy, projection} {}
+    Camera3D(
+        ::Vector3 position,
+        ::Vector3 target = ::Vector3{0.0f, 0.0f, 0.0f},
+        ::Vector3 up = ::Vector3{0.0f, 1.0f, 0.0f},
+        float fovy = 0,
+        int projection = CAMERA_PERSPECTIVE)
+        : ::Camera3D{position, target, up, fovy, projection} {}
 
     Camera3D() {}
 
@@ -62,9 +63,7 @@ class Camera3D : public ::Camera3D {
     /**
      * Get camera transform matrix (view matrix)
      */
-    Matrix GetMatrix() const {
-        return ::GetCameraMatrix(*this);
-    }
+    Matrix GetMatrix() const { return ::GetCameraMatrix(*this); }
 
     /**
      * Update camera position for selected mode
@@ -85,25 +84,18 @@ class Camera3D : public ::Camera3D {
     /**
      * Returns a ray trace from mouse position
      */
-    Ray GetMouseRay(::Vector2 mousePosition) const {
-        return ::GetMouseRay(mousePosition, *this);
-    }
+    Ray GetMouseRay(::Vector2 mousePosition) const { return ::GetMouseRay(mousePosition, *this); }
 
     /**
      * Returns the screen space position for a 3d world space position
      */
-    Vector2 GetWorldToScreen(::Vector3 position) const {
-        return ::GetWorldToScreen(position, *this);
-    }
+    Vector2 GetWorldToScreen(::Vector3 position) const { return ::GetWorldToScreen(position, *this); }
 
     /**
      * Draw a billboard texture.
      */
-    void DrawBillboard(
-            const ::Texture2D& texture,
-            ::Vector3 center,
-            float size,
-            ::Color tint = {255, 255, 255, 255}) const {
+    void
+    DrawBillboard(const ::Texture2D& texture, ::Vector3 center, float size, ::Color tint = {255, 255, 255, 255}) const {
         ::DrawBillboard(*this, texture, center, size, tint);
     }
 
@@ -111,15 +103,14 @@ class Camera3D : public ::Camera3D {
      * Draw a billboard texture defined by source.
      */
     void DrawBillboard(
-            const ::Texture2D& texture,
-            ::Rectangle sourceRec,
-            ::Vector3 center,
-            ::Vector2 size,
-            ::Color tint = {255, 255, 255, 255}) const {
+        const ::Texture2D& texture,
+        ::Rectangle sourceRec,
+        ::Vector3 center,
+        ::Vector2 size,
+        ::Color tint = {255, 255, 255, 255}) const {
         ::DrawBillboardRec(*this, texture, sourceRec, center, size, tint);
     }
-
- protected:
+protected:
     void set(const ::Camera3D& camera) {
         position = camera.position;
         target = camera.target;
@@ -131,9 +122,9 @@ class Camera3D : public ::Camera3D {
 
 using Camera = Camera3D;
 
-}  // namespace raylib
+} // namespace raylib
 
 using RCamera = raylib::Camera;
 using RCamera3D = raylib::Camera3D;
 
-#endif  // RAYLIB_CPP_INCLUDE_CAMERA3D_HPP_
+#endif // RAYLIB_CPP_INCLUDE_CAMERA3D_HPP_

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -3,23 +3,20 @@
 
 #include <string>
 
-#include "./raylib.hpp"
 #include "./Vector4.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Color type, RGBA (32bit)
  */
 class Color : public ::Color {
- public:
+public:
     Color(const ::Color& color) : ::Color{color.r, color.g, color.b, color.a} {}
 
-    Color(
-            unsigned char red,
-            unsigned char green,
-            unsigned char blue,
-            unsigned char alpha = 255) : ::Color{red, green, blue, alpha} {};
+    Color(unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha = 255)
+        : ::Color{red, green, blue, alpha} {};
 
     /**
      * Black.
@@ -29,77 +26,53 @@ class Color : public ::Color {
     /**
      * Returns a Color from HSV values
      */
-    Color(::Vector3 hsv) {
-        set(::ColorFromHSV(hsv.x, hsv.y, hsv.z));
-    }
+    Color(::Vector3 hsv) { set(::ColorFromHSV(hsv.x, hsv.y, hsv.z)); }
 
     /**
      * Returns a Color from HSV values
      */
-    static ::Color FromHSV(float hue, float saturation, float value) {
-        return ::ColorFromHSV(hue, saturation, value);
-    }
+    static ::Color FromHSV(float hue, float saturation, float value) { return ::ColorFromHSV(hue, saturation, value); }
 
     /**
      * Get Color structure from hexadecimal value
      */
-    Color(unsigned int hexValue) {
-        set(::GetColor(hexValue));
-    }
+    Color(unsigned int hexValue) { set(::GetColor(hexValue)); }
 
-    Color(void *srcPtr, int format) {
-        set(::GetPixelColor(srcPtr, format));
-    }
+    Color(void* srcPtr, int format) { set(::GetPixelColor(srcPtr, format)); }
 
     /**
      * Returns hexadecimal value for a Color
      */
-    int ToInt() const {
-        return ::ColorToInt(*this);
-    }
+    int ToInt() const { return ::ColorToInt(*this); }
 
     /**
      * Returns hexadecimal value for a Color
      */
-    operator int() const {
-        return ::ColorToInt(*this);
-    }
+    operator int() const { return ::ColorToInt(*this); }
 
-    std::string ToString() const {
-        return TextFormat("Color(%d, %d, %d, %d)", r, g, b, a);
-    }
+    std::string ToString() const { return TextFormat("Color(%d, %d, %d, %d)", r, g, b, a); }
 
-    operator std::string() const {
-        return ToString();
-    }
+    operator std::string() const { return ToString(); }
 
     /**
      * Returns color with alpha applied, alpha goes from 0.0f to 1.0f
      */
-    Color Fade(float alpha) const {
-        return ::Fade(*this, alpha);
-    }
+    Color Fade(float alpha) const { return ::Fade(*this, alpha); }
 
     /**
      * Returns Color normalized as float [0..1]
      */
-    Vector4 Normalize() const {
-        return ::ColorNormalize(*this);
-    }
+    Vector4 Normalize() const { return ::ColorNormalize(*this); }
 
     /**
      * Returns Color from normalized values [0..1]
      */
-    Color(::Vector4 normalized) {
-        set(::ColorFromNormalized(normalized));
-    }
+    Color(::Vector4 normalized) { set(::ColorFromNormalized(normalized)); }
 
     /**
      * Returns HSV values for a Color
      */
-    Vector3 ToHSV() const {
-        return ::ColorToHSV(*this);
-    }
+    Vector3 ToHSV() const { return ::ColorToHSV(*this); }
 
     GETTERSETTER(unsigned char, R, r)
     GETTERSETTER(unsigned char, G, g)
@@ -119,16 +92,12 @@ class Color : public ::Color {
         return *this;
     }
 
-    void DrawPixel(int x, int y) const {
-        ::DrawPixel(x, y, *this);
-    }
+    void DrawPixel(int x, int y) const { ::DrawPixel(x, y, *this); }
 
     /**
      * Draw a pixel
      */
-    void DrawPixel(::Vector2 pos) const {
-        ::DrawPixelV(pos, *this);
-    }
+    void DrawPixel(::Vector2 pos) const { ::DrawPixelV(pos, *this); }
 
     /**
      * Draw a line
@@ -140,9 +109,7 @@ class Color : public ::Color {
     /**
      * Draw a line using Vector points
      */
-    void DrawLine(::Vector2 startPos, ::Vector2 endPos) const {
-        ::DrawLineV(startPos, endPos, *this);
-    }
+    void DrawLine(::Vector2 startPos, ::Vector2 endPos) const { ::DrawLineV(startPos, endPos, *this); }
 
     /**
      * Draw a line using Vector points, with a given thickness
@@ -155,9 +122,7 @@ class Color : public ::Color {
         ::DrawLineBezier(startPos, endPos, thick, *this);
     }
 
-    void DrawLineStrip(::Vector2 *points, int numPoints) const {
-        ::DrawLineStrip(points, numPoints, *this);
-    }
+    void DrawLineStrip(::Vector2* points, int numPoints) const { ::DrawLineStrip(points, numPoints, *this); }
 
     void DrawText(const char* text, int posX = 0, int posY = 0, int fontSize = 10.0f) const {
         ::DrawText(text, posX, posY, fontSize, *this);
@@ -167,35 +132,34 @@ class Color : public ::Color {
         ::DrawText(text.c_str(), posX, posY, fontSize, *this);
     }
 
-    void DrawText(const ::Font& font, const char* text, ::Vector2 position,
-            float fontSize, float spacing) const {
+    void DrawText(const ::Font& font, const char* text, ::Vector2 position, float fontSize, float spacing) const {
         ::DrawTextEx(font, text, position, fontSize, spacing, *this);
     }
 
-    void DrawText(const ::Font& font, const std::string& text, ::Vector2 position,
-            float fontSize, float spacing) const {
+    void
+    DrawText(const ::Font& font, const std::string& text, ::Vector2 position, float fontSize, float spacing) const {
         ::DrawTextEx(font, text.c_str(), position, fontSize, spacing, *this);
     }
 
     void DrawText(
-            const ::Font& font,
-            const char* text,
-            ::Vector2 position,
-            ::Vector2 origin,
-            float rotation,
-            float fontSize,
-            float spacing) const {
+        const ::Font& font,
+        const char* text,
+        ::Vector2 position,
+        ::Vector2 origin,
+        float rotation,
+        float fontSize,
+        float spacing) const {
         ::DrawTextPro(font, text, position, origin, rotation, fontSize, spacing, *this);
     }
 
     void DrawText(
-            const ::Font& font,
-            const std::string& text,
-            ::Vector2 position,
-            ::Vector2 origin,
-            float rotation,
-            float fontSize,
-            float spacing) const {
+        const ::Font& font,
+        const std::string& text,
+        ::Vector2 position,
+        ::Vector2 origin,
+        float rotation,
+        float fontSize,
+        float spacing) const {
         ::DrawTextPro(font, text.c_str(), position, origin, rotation, fontSize, spacing, *this);
     }
 
@@ -203,13 +167,9 @@ class Color : public ::Color {
         ::DrawRectangle(posX, posY, width, height, *this);
     }
 
-    void DrawRectangle(::Vector2 position, ::Vector2 size) const {
-        ::DrawRectangleV(position, size, *this);
-    }
+    void DrawRectangle(::Vector2 position, ::Vector2 size) const { ::DrawRectangleV(position, size, *this); }
 
-    void DrawRectangle(::Rectangle rec) const {
-        ::DrawRectangleRec(rec, *this);
-    }
+    void DrawRectangle(::Rectangle rec) const { ::DrawRectangleRec(rec, *this); }
 
     void DrawRectangle(::Rectangle rec, ::Vector2 origin, float rotation) const {
         ::DrawRectanglePro(rec, origin, rotation, *this);
@@ -219,44 +179,32 @@ class Color : public ::Color {
         ::DrawRectangleLines(posX, posY, width, height, *this);
     }
 
-    void DrawRectangleLines(::Rectangle rec, float lineThick) const {
-        ::DrawRectangleLinesEx(rec, lineThick, *this);
-    }
+    void DrawRectangleLines(::Rectangle rec, float lineThick) const { ::DrawRectangleLinesEx(rec, lineThick, *this); }
 
     /**
      * Get color multiplied with another color
      */
-    Color Tint(::Color tint) {
-        return ::ColorTint(*this, tint);
-    }
+    Color Tint(::Color tint) { return ::ColorTint(*this, tint); }
 
     /**
      * Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
      */
-    Color Brightness(float factor) {
-        return ::ColorBrightness(*this, factor);
-    }
+    Color Brightness(float factor) { return ::ColorBrightness(*this, factor); }
 
     /**
      * Get color with contrast correction, contrast values between -1.0f and 1.0f
      */
-    Color Contrast(float contrast) {
-        return ::ColorContrast(*this, contrast);
-    }
+    Color Contrast(float contrast) { return ::ColorContrast(*this, contrast); }
 
     /**
      * Returns color with alpha applied, alpha goes from 0.0f to 1.0f
      */
-    Color Alpha(float alpha) const {
-        return ::ColorAlpha(*this, alpha);
-    }
+    Color Alpha(float alpha) const { return ::ColorAlpha(*this, alpha); }
 
     /**
      * Returns src alpha-blended into dst color with tint
      */
-    Color AlphaBlend(::Color dst, ::Color tint) const {
-        return ::ColorAlphaBlend(dst, *this, tint);
-    }
+    Color AlphaBlend(::Color dst, ::Color tint) const { return ::ColorAlphaBlend(dst, *this, tint); }
 
     static Color LightGray() { return LIGHTGRAY; }
     static Color Gray() { return GRAY; }
@@ -284,8 +232,7 @@ class Color : public ::Color {
     static Color Blank() { return BLANK; }
     static Color Magenta() { return MAGENTA; }
     static Color RayWhite() { return RAYWHITE; }
-
- protected:
+protected:
     void set(const ::Color& color) {
         r = color.r;
         g = color.g;
@@ -294,8 +241,8 @@ class Color : public ::Color {
     }
 };
 
-}  // namespace raylib
+} // namespace raylib
 
 using RColor = raylib::Color;
 
-#endif  // RAYLIB_CPP_INCLUDE_COLOR_HPP_
+#endif // RAYLIB_CPP_INCLUDE_COLOR_HPP_

--- a/include/FileData.hpp
+++ b/include/FileData.hpp
@@ -4,13 +4,13 @@
 #include <string>
 #include <utility>
 
-#include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 
 class FileData {
- public:
+public:
     FileData() = default;
     FileData(const FileData&) = delete;
     FileData(FileData&& other) noexcept : data(other.data), bytesRead(other.bytesRead) {
@@ -25,17 +25,13 @@ class FileData {
     }
     ~FileData() { Unload(); }
 
-    explicit FileData(const std::string& fileName) {
-        Load(fileName);
-    }
+    explicit FileData(const std::string& fileName) { Load(fileName); }
 
     GETTER(const unsigned char*, Data, data)
     GETTER(int, BytesRead, bytesRead)
 
     void Load(const std::string& fileName) { Load(fileName.c_str()); }
-    void Load(const char* fileName) {
-        data = ::LoadFileData(fileName, &bytesRead);
-    }
+    void Load(const char* fileName) { data = ::LoadFileData(fileName, &bytesRead); }
 
     void Unload() {
         if (data != nullptr) {
@@ -43,14 +39,13 @@ class FileData {
             data = nullptr;
         }
     }
-
- private:
+private:
     unsigned char* data{nullptr};
     int bytesRead{0};
 };
 
-}  // namespace raylib
+} // namespace raylib
 
 using RFileData = raylib::FileData;
 
-#endif  // RAYLIB_CPP_INCLUDE_FILEDATA_HPP_
+#endif // RAYLIB_CPP_INCLUDE_FILEDATA_HPP_

--- a/include/FileText.hpp
+++ b/include/FileText.hpp
@@ -4,13 +4,13 @@
 #include <string>
 #include <utility>
 
-#include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 
 class FileText {
- public:
+public:
     FileText() = default;
     FileText(const FileText&) = delete;
     FileText(FileText&& other) noexcept : data(other.data), length(other.length) {
@@ -25,9 +25,7 @@ class FileText {
     }
     ~FileText() { Unload(); }
 
-    explicit FileText(const std::string& fileName) {
-        Load(fileName);
-    }
+    explicit FileText(const std::string& fileName) { Load(fileName); }
 
     GETTER(const char*, Data, data)
     GETTER(unsigned int, Length, length)
@@ -35,9 +33,7 @@ class FileText {
     [[nodiscard]] const char* c_str() const { return data; }
 
     [[nodiscard]] std::string ToString() const { return data; }
-    explicit operator std::string() const {
-        return data;
-    }
+    explicit operator std::string() const { return data; }
 
     void Load(const std::string& fileName) { Load(fileName.c_str()); }
     void Load(const char* fileName) {
@@ -52,14 +48,13 @@ class FileText {
             length = 0;
         }
     }
-
- private:
+private:
     char* data{nullptr};
     unsigned int length{0};
 };
 
-}  // namespace raylib
+} // namespace raylib
 
 using RFileText = raylib::FileText;
 
-#endif  // RAYLIB_CPP_INCLUDE_FILETEXT_HPP_
+#endif // RAYLIB_CPP_INCLUDE_FILETEXT_HPP_

--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -3,36 +3,34 @@
 
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
 #include "./TextureUnmanaged.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Font type, includes texture and charSet array data
  */
 class Font : public ::Font {
- public:
-    Font(int baseSize,
-            int glyphCount,
-            int glyphPadding,
-            ::Texture2D texture,
-            ::Rectangle *recs = nullptr,
-            ::GlyphInfo *glyphs = nullptr) : ::Font{baseSize, glyphCount, glyphPadding, texture, recs, glyphs} {
+public:
+    Font(
+        int baseSize,
+        int glyphCount,
+        int glyphPadding,
+        ::Texture2D texture,
+        ::Rectangle* recs = nullptr,
+        ::GlyphInfo* glyphs = nullptr)
+        : ::Font{baseSize, glyphCount, glyphPadding, texture, recs, glyphs} {
         // Nothing.
     }
 
     /**
      * Retrieves the default Font.
      */
-    Font() {
-        set(::GetFontDefault());
-    }
+    Font() { set(::GetFontDefault()); }
 
-    Font(const ::Font& font) {
-        set(font);
-    }
+    Font(const ::Font& font) { set(font); }
 
     /**
      * Loads a Font from the given file.
@@ -41,9 +39,7 @@ class Font : public ::Font {
      *
      * @throws raylib::RaylibException Throws if the given font failed to initialize.
      */
-    Font(const std::string& fileName) {
-        Load(fileName);
-    }
+    Font(const std::string& fileName) { Load(fileName); }
 
     /**
      * Loads a Font from the given file, with generation parameters.
@@ -54,7 +50,7 @@ class Font : public ::Font {
      *
      * @see ::LoadFontEx
      */
-    Font(const std::string& fileName, int fontSize, int* fontChars = 0, int charCount = 0)  {
+    Font(const std::string& fileName, int fontSize, int* fontChars = 0, int charCount = 0) {
         Load(fileName, fontSize, fontChars, charCount);
     }
 
@@ -67,9 +63,7 @@ class Font : public ::Font {
      *
      * @see ::LoadFontFromImage()
      */
-    Font(const ::Image& image, ::Color key, int firstChar) {
-        Load(image, key, firstChar);
-    }
+    Font(const ::Image& image, ::Color key, int firstChar) { Load(image, key, firstChar); }
 
     /**
      * Loads a font from memory, based on the given file type and file data.
@@ -78,8 +72,13 @@ class Font : public ::Font {
      *
      * @see ::LoadFontFromMemory()
      */
-    Font(const std::string& fileType, const unsigned char* fileData, int dataSize, int fontSize,
-            int *fontChars, int charsCount)  {
+    Font(
+        const std::string& fileType,
+        const unsigned char* fileData,
+        int dataSize,
+        int fontSize,
+        int* fontChars,
+        int charsCount) {
         Load(fileType, fileData, dataSize, fontSize, fontChars, charsCount);
     }
 
@@ -96,9 +95,7 @@ class Font : public ::Font {
         other.glyphs = nullptr;
     }
 
-    ~Font() {
-        Unload();
-    }
+    ~Font() { Unload(); }
 
     void Unload() {
         // Protect against calling UnloadFont() twice.
@@ -117,16 +114,12 @@ class Font : public ::Font {
     /**
      * Get the texture atlas containing the glyphs.
      */
-    TextureUnmanaged GetTexture() {
-        return texture;
-    }
+    TextureUnmanaged GetTexture() { return texture; }
 
     /**
      * Set the texture atlas containing the glyphs.
      */
-    void SetTexture(const ::Texture& newTexture) {
-        texture = newTexture;
-    }
+    void SetTexture(const ::Texture& newTexture) { texture = newTexture; }
 
     Font& operator=(const ::Font& font) {
         Unload();
@@ -180,7 +173,7 @@ class Font : public ::Font {
      *
      * @see ::LoadFontEx()
      */
-    void Load(const std::string& fileName, int fontSize, int* fontChars, int charCount)  {
+    void Load(const std::string& fileName, int fontSize, int* fontChars, int charCount) {
         set(::LoadFontEx(fileName.c_str(), fontSize, fontChars, charCount));
         if (!IsReady()) {
             throw RaylibException("Failed to load Font with from file with font size: " + fileName);
@@ -194,10 +187,14 @@ class Font : public ::Font {
         }
     }
 
-    void Load(const std::string& fileType, const unsigned char* fileData, int dataSize, int fontSize,
-            int *fontChars, int charsCount)  {
-        set(::LoadFontFromMemory(fileType.c_str(), fileData, dataSize, fontSize, fontChars,
-            charsCount));
+    void Load(
+        const std::string& fileType,
+        const unsigned char* fileData,
+        int dataSize,
+        int fontSize,
+        int* fontChars,
+        int charsCount) {
+        set(::LoadFontFromMemory(fileType.c_str(), fileData, dataSize, fontSize, fontChars, charsCount));
         if (!IsReady()) {
             throw RaylibException("Failed to load Font " + fileType + " with from file data");
         }
@@ -206,95 +203,84 @@ class Font : public ::Font {
     /**
      * Returns if the font is ready to be used.
      */
-    bool IsReady() const {
-        return ::IsFontReady(*this);
+    bool IsReady() const { return ::IsFontReady(*this); }
+
+    /**
+     * Draw text using font and additional parameters.
+     */
+    void DrawText(const char* text, ::Vector2 position, float fontSize, float spacing, ::Color tint = WHITE) const {
+        ::DrawTextEx(*this, text, position, fontSize, spacing, tint);
     }
 
     /**
      * Draw text using font and additional parameters.
      */
-    void DrawText(const char* text, ::Vector2 position, float fontSize,
-            float spacing, ::Color tint = WHITE) const {
-        ::DrawTextEx(*this, text, position,  fontSize,  spacing,  tint);
+    void
+    DrawText(const std::string& text, ::Vector2 position, float fontSize, float spacing, ::Color tint = WHITE) const {
+        ::DrawTextEx(*this, text.c_str(), position, fontSize, spacing, tint);
     }
 
     /**
      * Draw text using font and additional parameters.
      */
-    void DrawText(const std::string& text, ::Vector2 position, float fontSize,
-            float spacing, ::Color tint = WHITE) const {
-        ::DrawTextEx(*this, text.c_str(), position,  fontSize,  spacing,  tint);
+    void DrawText(const char* text, int posX, int posY, float fontSize, float spacing, ::Color tint = WHITE) const {
+        ::DrawTextEx(*this, text, {static_cast<float>(posX), static_cast<float>(posY)}, fontSize, spacing, tint);
     }
 
     /**
      * Draw text using font and additional parameters.
      */
-    void DrawText(const char* text, int posX, int posY, float fontSize,
-            float spacing, ::Color tint = WHITE) const {
-        ::DrawTextEx(*this, text,
-            { static_cast<float>(posX), static_cast<float>(posY) },
-            fontSize, spacing, tint);
-    }
-
-    /**
-     * Draw text using font and additional parameters.
-     */
-    void DrawText(const std::string& text, int posX, int posY, float fontSize,
-            float spacing, ::Color tint = WHITE) const {
-        ::DrawTextEx(*this, text.c_str(),
-            { static_cast<float>(posX), static_cast<float>(posY) },
-            fontSize, spacing, tint);
+    void
+    DrawText(const std::string& text, int posX, int posY, float fontSize, float spacing, ::Color tint = WHITE) const {
+        ::DrawTextEx(
+            *this,
+            text.c_str(),
+            {static_cast<float>(posX), static_cast<float>(posY)},
+            fontSize,
+            spacing,
+            tint);
     }
 
     void DrawText(
-            const char* text,
-            ::Vector2 position,
-            ::Vector2 origin,
-            float rotation,
-            float fontSize,
-            float spacing,
-            ::Color tint = WHITE) const {
-        ::DrawTextPro(*this, text,
-            position, origin,
-            rotation, fontSize,
-            spacing, tint);
+        const char* text,
+        ::Vector2 position,
+        ::Vector2 origin,
+        float rotation,
+        float fontSize,
+        float spacing,
+        ::Color tint = WHITE) const {
+        ::DrawTextPro(*this, text, position, origin, rotation, fontSize, spacing, tint);
     }
 
     void DrawText(
-            const std::string& text,
-            ::Vector2 position,
-            ::Vector2 origin,
-            float rotation,
-            float fontSize,
-            float spacing,
-            ::Color tint = WHITE) const {
-        ::DrawTextPro(*this, text.c_str(),
-            position, origin,
-            rotation, fontSize,
-            spacing, tint);
+        const std::string& text,
+        ::Vector2 position,
+        ::Vector2 origin,
+        float rotation,
+        float fontSize,
+        float spacing,
+        ::Color tint = WHITE) const {
+        ::DrawTextPro(*this, text.c_str(), position, origin, rotation, fontSize, spacing, tint);
     }
 
     /**
      * Draw one character (codepoint)
      */
-    void DrawText(int codepoint,
-            ::Vector2 position,
-            float fontSize,
-            ::Color tint = { 255, 255, 255, 255 }) const {
+    void DrawText(int codepoint, ::Vector2 position, float fontSize, ::Color tint = {255, 255, 255, 255}) const {
         ::DrawTextCodepoint(*this, codepoint, position, fontSize, tint);
     }
 
     /**
      * Draw multiple character (codepoint)
      */
-    void DrawText(const int *codepoints,
-            int count, ::Vector2 position,
-            float fontSize, float spacing,
-            ::Color tint = { 255, 255, 255, 255 }) const {
-        ::DrawTextCodepoints(*this,
-            codepoints, count,
-            position, fontSize,
-            spacing, tint);
+    void DrawText(
+        const int* codepoints,
+        int count,
+        ::Vector2 position,
+        float fontSize,
+        float spacing,
+        ::Color tint = {255, 255, 255, 255}) const {
+        ::DrawTextCodepoints(*this, codepoints, count, position, fontSize, spacing, tint);
     }
 
     /**
@@ -314,27 +300,22 @@ class Font : public ::Font {
     /**
      * Get index position for a unicode character on font
      */
-    int GetGlyphIndex(int character) const {
-        return ::GetGlyphIndex(*this, character);
-    }
+    int GetGlyphIndex(int character) const { return ::GetGlyphIndex(*this, character); }
 
     /**
      * Create an image from text (custom sprite font)
      */
-    ::Image ImageText(const char* text, float fontSize,
-            float spacing, ::Color tint) const {
+    ::Image ImageText(const char* text, float fontSize, float spacing, ::Color tint) const {
         return ::ImageTextEx(*this, text, fontSize, spacing, tint);
     }
 
     /**
      * Create an image from text (custom sprite font)
      */
-    ::Image ImageText(const std::string& text, float fontSize,
-            float spacing, ::Color tint) const {
+    ::Image ImageText(const std::string& text, float fontSize, float spacing, ::Color tint) const {
         return ::ImageTextEx(*this, text.c_str(), fontSize, spacing, tint);
     }
-
- protected:
+protected:
     void set(const ::Font& font) {
         baseSize = font.baseSize;
         glyphCount = font.glyphCount;
@@ -344,8 +325,8 @@ class Font : public ::Font {
         glyphs = font.glyphs;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RFont = raylib::Font;
 
-#endif  // RAYLIB_CPP_INCLUDE_FONT_HPP_
+#endif // RAYLIB_CPP_INCLUDE_FONT_HPP_

--- a/include/Functions.hpp
+++ b/include/Functions.hpp
@@ -201,25 +201,23 @@ namespace raylib {
 /**
  * Load an image from RAW file data
  */
-[[maybe_unused]] RLCPPAPI inline ::Image LoadImageRaw(const std::string& fileName,
-        int width, int height,
-        int format, int headerSize) {
+[[maybe_unused]] RLCPPAPI inline ::Image
+LoadImageRaw(const std::string& fileName, int width, int height, int format, int headerSize) {
     return ::LoadImageRaw(fileName.c_str(), width, height, format, headerSize);
 }
 
 /**
  * Load animated image data
  */
-[[maybe_unused]] RLCPPAPI inline ::Image LoadImageAnim(const std::string& fileName, int *frames) {
+[[maybe_unused]] RLCPPAPI inline ::Image LoadImageAnim(const std::string& fileName, int* frames) {
     return ::LoadImageAnim(fileName.c_str(), frames);
 }
 
 /**
  * Load image from memory buffer, fileType refers to extension like "png"
  */
-[[maybe_unused]] RLCPPAPI inline ::Image LoadImageFromMemory(const std::string& fileType,
-        const unsigned char *fileData,
-        int dataSize) {
+[[maybe_unused]] RLCPPAPI inline ::Image
+LoadImageFromMemory(const std::string& fileType, const unsigned char* fileData, int dataSize) {
     return ::LoadImageFromMemory(fileType.c_str(), fileData, dataSize);
 }
 
@@ -247,43 +245,54 @@ namespace raylib {
 /**
  * Draw text (using default font)
  */
-[[maybe_unused]] RLCPPAPI inline void DrawText(
-        const std::string& text,
-        int posX, int posY,
-        int fontSize,
-        ::Color color) {
+[[maybe_unused]] RLCPPAPI inline void
+DrawText(const std::string& text, int posX, int posY, int fontSize, ::Color color) {
     ::DrawText(text.c_str(), posX, posY, fontSize, color);
 }
 
 /**
  * Draw text using font and additional parameters
  */
-[[maybe_unused]] RLCPPAPI inline void DrawTextEx(const Font& font, char* text, Vector2 position,
-        float fontSize, float spacing, ::Color tint) {
+[[maybe_unused]] RLCPPAPI inline void
+DrawTextEx(const Font& font, char* text, Vector2 position, float fontSize, float spacing, ::Color tint) {
     ::DrawTextEx(font, text, position, fontSize, spacing, tint);
 }
 
 /**
  * Draw text using font and additional parameters
  */
-[[maybe_unused]] RLCPPAPI inline void DrawTextEx(const Font& font, const std::string& text, Vector2 position,
-        float fontSize, float spacing, ::Color tint) {
+[[maybe_unused]] RLCPPAPI inline void
+DrawTextEx(const Font& font, const std::string& text, Vector2 position, float fontSize, float spacing, ::Color tint) {
     ::DrawTextEx(font, text.c_str(), position, fontSize, spacing, tint);
 }
 
 /**
  * Draw text using Font and pro parameters (rotation)
  */
-[[maybe_unused]] RLCPPAPI inline void DrawTextPro(const Font& font, const char* text, Vector2 position,
-        Vector2 origin, float rotation, float fontSize, float spacing, ::Color tint) {
+[[maybe_unused]] RLCPPAPI inline void DrawTextPro(
+    const Font& font,
+    const char* text,
+    Vector2 position,
+    Vector2 origin,
+    float rotation,
+    float fontSize,
+    float spacing,
+    ::Color tint) {
     ::DrawTextPro(font, text, position, origin, rotation, fontSize, spacing, tint);
 }
 
 /**
  * Draw text using Font and pro parameters (rotation)
  */
-[[maybe_unused]] RLCPPAPI inline void DrawTextPro(const Font& font, const std::string& text, Vector2 position,
-        Vector2 origin, float rotation, float fontSize, float spacing, ::Color tint) {
+[[maybe_unused]] RLCPPAPI inline void DrawTextPro(
+    const Font& font,
+    const std::string& text,
+    Vector2 position,
+    Vector2 origin,
+    float rotation,
+    float fontSize,
+    float spacing,
+    ::Color tint) {
     ::DrawTextPro(font, text.c_str(), position, origin, rotation, fontSize, spacing, tint);
 }
 
@@ -297,10 +306,8 @@ namespace raylib {
 /**
  * Load font from file (filename must include file extension)
  */
-[[maybe_unused]] RLCPPAPI inline ::Font LoadFontEx(
-        const std::string& fileName,
-        int fontSize, int *fontChars,
-        int charsCount) {
+[[maybe_unused]] RLCPPAPI inline ::Font
+LoadFontEx(const std::string& fileName, int fontSize, int* fontChars, int charsCount) {
     return ::LoadFontEx(fileName.c_str(), fontSize, fontChars, charsCount);
 }
 
@@ -356,9 +363,8 @@ namespace raylib {
 /**
  * Replace text string
  */
-[[maybe_unused]] RLCPPAPI std::string TextReplace(
-        const std::string& text, const std::string& replace,
-        const std::string& by) {
+[[maybe_unused]] RLCPPAPI std::string
+TextReplace(const std::string& text, const std::string& replace, const std::string& by) {
     const char* input = text.c_str();
     char* output = ::TextReplace(const_cast<char*>(input), replace.c_str(), by.c_str());
     if (output != NULL) {
@@ -426,6 +432,6 @@ namespace raylib {
     return ::TextToInteger(text.c_str());
 }
 
-}  // namespace raylib
+} // namespace raylib
 
-#endif  // RAYLIB_CPP_INCLUDE_FUNCTIONS_HPP_
+#endif // RAYLIB_CPP_INCLUDE_FUNCTIONS_HPP_

--- a/include/Gamepad.hpp
+++ b/include/Gamepad.hpp
@@ -3,18 +3,16 @@
 
 #include <string>
 
-#include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Input-related functions: gamepads
  */
 class Gamepad {
- public:
-    Gamepad(int gamepadNumber = 0) {
-        set(gamepadNumber);
-    }
+public:
+    Gamepad(int gamepadNumber = 0) { set(gamepadNumber); }
     int number;
 
     GETTERSETTER(int, Number, number)
@@ -34,91 +32,64 @@ class Gamepad {
     /**
      * Detect if a gamepad is available
      */
-    bool IsAvailable() const {
-        return ::IsGamepadAvailable(number);
-    }
+    bool IsAvailable() const { return ::IsGamepadAvailable(number); }
 
     /**
      * Detect if a gamepad is available
      */
-    static bool IsAvailable(int number) {
-        return ::IsGamepadAvailable(number);
-    }
+    static bool IsAvailable(int number) { return ::IsGamepadAvailable(number); }
 
     /**
      * Return gamepad internal name id
      */
-    std::string GetName() const {
-        return ::GetGamepadName(number);
-    }
+    std::string GetName() const { return ::GetGamepadName(number); }
 
     /**
      * Return gamepad internal name id
      */
-    operator std::string() const {
-        return GetName();
-    }
+    operator std::string() const { return GetName(); }
 
     /**
      * Detect if a gamepad button has been pressed once
      */
-    bool IsButtonPressed(int button) const {
-        return ::IsGamepadButtonPressed(number, button);
-    }
+    bool IsButtonPressed(int button) const { return ::IsGamepadButtonPressed(number, button); }
 
     /**
      * Detect if a gamepad button is being pressed
      */
-    bool IsButtonDown(int button) const {
-        return ::IsGamepadButtonDown(number, button);
-    }
+    bool IsButtonDown(int button) const { return ::IsGamepadButtonDown(number, button); }
 
     /**
      * Detect if a gamepad button has been released once
      */
-    bool IsButtonReleased(int button) const {
-        return ::IsGamepadButtonReleased(number, button);
-    }
+    bool IsButtonReleased(int button) const { return ::IsGamepadButtonReleased(number, button); }
 
     /**
      * Detect if a gamepad button is NOT being pressed
      */
-    bool IsButtonUp(int button) const {
-        return ::IsGamepadButtonUp(number, button);
-    }
+    bool IsButtonUp(int button) const { return ::IsGamepadButtonUp(number, button); }
 
     /**
      * Get the last gamepad button pressed
      */
-    int GetButtonPressed() const {
-        return ::GetGamepadButtonPressed();
-    }
+    int GetButtonPressed() const { return ::GetGamepadButtonPressed(); }
 
     /**
      * Return gamepad axis count for a gamepad
      */
-    int GetAxisCount() const {
-        return ::GetGamepadAxisCount(number);
-    }
+    int GetAxisCount() const { return ::GetGamepadAxisCount(number); }
 
     /**
      * Return axis movement value for a gamepad axis
      */
-    float GetAxisMovement(int axis) const {
-        return ::GetGamepadAxisMovement(number, axis);
-    }
+    float GetAxisMovement(int axis) const { return ::GetGamepadAxisMovement(number, axis); }
 
-    int SetMappings(const std::string& mappings) {
-        return SetGamepadMappings(mappings.c_str());
-    }
-
- protected:
-    void set(int gamepadNumber) {
-        number = gamepadNumber;
-    }
+    int SetMappings(const std::string& mappings) { return SetGamepadMappings(mappings.c_str()); }
+protected:
+    void set(int gamepadNumber) { number = gamepadNumber; }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RGamepad = raylib::Gamepad;
 
-#endif  // RAYLIB_CPP_INCLUDE_GAMEPAD_HPP_
+#endif // RAYLIB_CPP_INCLUDE_GAMEPAD_HPP_

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -3,10 +3,10 @@
 
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
-#include "./RaylibException.hpp"
 #include "./Color.hpp"
+#include "./RaylibException.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
@@ -15,18 +15,18 @@ namespace raylib {
  * Data stored in CPU memory (RAM)
  */
 class Image : public ::Image {
- public:
-    Image(void* data = nullptr,
-            int width = 0,
-            int height = 0,
-            int mipmaps = 1,
-            int format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8) : ::Image{data, width, height, mipmaps, format} {
+public:
+    Image(
+        void* data = nullptr,
+        int width = 0,
+        int height = 0,
+        int mipmaps = 1,
+        int format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8)
+        : ::Image{data, width, height, mipmaps, format} {
         // Nothing.
     }
 
-    Image(const ::Image& image) {
-        set(image);
-    }
+    Image(const ::Image& image) { set(image); }
 
     /**
      * Load an image from the given file.
@@ -35,9 +35,7 @@ class Image : public ::Image {
      *
      * @see Load()
      */
-    Image(const std::string& fileName) {
-        Load(fileName);
-    }
+    Image(const std::string& fileName) { Load(fileName); }
 
     /**
      * Load a raw image from the given file, with the provided width, height, and formats.
@@ -57,9 +55,7 @@ class Image : public ::Image {
      *
      * @see LoadAnim()
      */
-    Image(const std::string& fileName, int* frames) {
-        Load(fileName, frames);
-    }
+    Image(const std::string& fileName, int* frames) { Load(fileName, frames); }
 
     /**
      * Load an image from the given file.
@@ -75,26 +71,24 @@ class Image : public ::Image {
      *
      * @throws raylib::RaylibException Thrown if the image failed to load from the file.
      */
-    Image(const ::Texture2D& texture) {
-        Load(texture);
-    }
+    Image(const ::Texture2D& texture) { Load(texture); }
 
-    Image(int width, int height, ::Color color = {255, 255, 255, 255}) {
-        set(::GenImageColor(width, height, color));
-    }
+    Image(int width, int height, ::Color color = {255, 255, 255, 255}) { set(::GenImageColor(width, height, color)); }
 
     Image(const std::string& text, int fontSize, ::Color color = {255, 255, 255, 255}) {
         set(::ImageText(text.c_str(), fontSize, color));
     }
 
-    Image(const ::Font& font, const std::string& text, float fontSize, float spacing,
-            ::Color tint = {255, 255, 255, 255}) {
+    Image(
+        const ::Font& font,
+        const std::string& text,
+        float fontSize,
+        float spacing,
+        ::Color tint = {255, 255, 255, 255}) {
         set(::ImageTextEx(font, text.c_str(), fontSize, spacing, tint));
     }
 
-    Image(const Image& other) {
-        set(other.Copy());
-    }
+    Image(const Image& other) { set(other.Copy()); }
 
     Image(Image&& other) {
         set(other);
@@ -106,22 +100,23 @@ class Image : public ::Image {
         other.format = 0;
     }
 
-    static ::Image Text(const std::string& text, int fontSize,
-            ::Color color = {255, 255, 255, 255}) {
+    static ::Image Text(const std::string& text, int fontSize, ::Color color = {255, 255, 255, 255}) {
         return ::ImageText(text.c_str(), fontSize, color);
     }
 
-    static ::Image Text(const ::Font& font, const std::string& text, float fontSize, float spacing,
-            ::Color tint = {255, 255, 255, 255}) {
+    static ::Image Text(
+        const ::Font& font,
+        const std::string& text,
+        float fontSize,
+        float spacing,
+        ::Color tint = {255, 255, 255, 255}) {
         return ::ImageTextEx(font, text.c_str(), fontSize, spacing, tint);
     }
 
     /**
      * Get pixel data from screen buffer and return an Image (screenshot)
      */
-    static ::Image LoadFromScreen() {
-        return ::LoadImageFromScreen();
-    }
+    static ::Image LoadFromScreen() { return ::LoadImageFromScreen(); }
 
     /**
      * Generate image: plain color
@@ -140,16 +135,20 @@ class Image : public ::Image {
     /**
      * Generate image: radial gradient
      */
-    static ::Image GradientRadial(int width, int height, float density,
-            ::Color inner, ::Color outer) {
+    static ::Image GradientRadial(int width, int height, float density, ::Color inner, ::Color outer) {
         return ::GenImageGradientRadial(width, height, density, inner, outer);
     }
 
     /**
      * Generate image: checked
      */
-    static ::Image Checked(int width, int height, int checksX, int checksY,
-            ::Color col1 = {255, 255, 255, 255}, ::Color col2 = {0, 0, 0, 255}) {
+    static ::Image Checked(
+        int width,
+        int height,
+        int checksX,
+        int checksY,
+        ::Color col1 = {255, 255, 255, 255},
+        ::Color col2 = {0, 0, 0, 255}) {
         return ::GenImageChecked(width, height, checksX, checksY, col1, col2);
     }
 
@@ -163,13 +162,9 @@ class Image : public ::Image {
     /**
      * Generate image: cellular algorithm. Bigger tileSize means bigger cells
      */
-    static ::Image Cellular(int width, int height, int tileSize) {
-        return ::GenImageCellular(width, height, tileSize);
-    }
+    static ::Image Cellular(int width, int height, int tileSize) { return ::GenImageCellular(width, height, tileSize); }
 
-    ~Image() {
-        Unload();
-    }
+    ~Image() { Unload(); }
 
     Image& operator=(const ::Image& image) {
         set(image);
@@ -253,10 +248,7 @@ class Image : public ::Image {
      *
      * @see ::LoadImageFromMemory()
      */
-    void Load(
-            const std::string& fileType,
-            const unsigned char *fileData,
-            int dataSize) {
+    void Load(const std::string& fileType, const unsigned char* fileData, int dataSize) {
         set(::LoadImageFromMemory(fileType.c_str(), fileData, dataSize));
         if (!IsReady()) {
             throw RaylibException("Failed to load Image data with file type: " + fileType);
@@ -301,7 +293,7 @@ class Image : public ::Image {
     /**
      * Export image to memory buffer
      */
-    unsigned char* ExportToMemory(const char *fileType, int *fileSize) {
+    unsigned char* ExportToMemory(const char* fileType, int* fileSize) {
         return ::ExportImageToMemory(*this, fileType, fileSize);
     }
 
@@ -343,23 +335,17 @@ class Image : public ::Image {
     /**
      * Retrieve the width and height of the image.
      */
-    ::Vector2 GetSize() const {
-        return {static_cast<float>(width), static_cast<float>(height)};
-    }
+    ::Vector2 GetSize() const { return {static_cast<float>(width), static_cast<float>(height)}; }
 
     /**
      * Create an image duplicate (useful for transformations)
      */
-    ::Image Copy() const {
-        return ::ImageCopy(*this);
-    }
+    ::Image Copy() const { return ::ImageCopy(*this); }
 
     /**
      * Create an image from another image piece
      */
-    ::Image FromImage(::Rectangle rec) const {
-        return ::ImageFromImage(*this, rec);
-    }
+    ::Image FromImage(::Rectangle rec) const { return ::ImageFromImage(*this, rec); }
 
     /**
      * Convert image data to desired format
@@ -420,16 +406,12 @@ class Image : public ::Image {
     /**
      * Crop an image to a new given width and height.
      */
-    Image& Crop(int newWidth, int newHeight) {
-        return Crop(0, 0, newWidth, newHeight);
-    }
+    Image& Crop(int newWidth, int newHeight) { return Crop(0, 0, newWidth, newHeight); }
 
     /**
      * Crop an image to a new given width and height based on a vector.
      */
-    Image& Crop(::Vector2 size) {
-        return Crop(0, 0, static_cast<int>(size.x), static_cast<int>(size.y));
-    }
+    Image& Crop(::Vector2 size) { return Crop(0, 0, static_cast<int>(size.x), static_cast<int>(size.y)); }
 
     /**
      * Crop an image to area defined by a rectangle
@@ -439,8 +421,7 @@ class Image : public ::Image {
             static_cast<float>(offsetX),
             static_cast<float>(offsetY),
             static_cast<float>(newWidth),
-            static_cast<float>(newHeight)
-        };
+            static_cast<float>(newHeight)};
         ::ImageCrop(this, rect);
         return *this;
     }
@@ -464,8 +445,8 @@ class Image : public ::Image {
     /**
      * Resize canvas and fill with color
      */
-    Image& ResizeCanvas(int newWidth, int newHeight, int offsetX = 0, int offsetY = 0,
-            ::Color color = {255, 255, 255, 255}) {
+    Image&
+    ResizeCanvas(int newWidth, int newHeight, int offsetX = 0, int offsetY = 0, ::Color color = {255, 255, 255, 255}) {
         ::ImageResizeCanvas(this, newWidth, newHeight, offsetX, offsetY, color);
         return *this;
     }
@@ -583,16 +564,12 @@ class Image : public ::Image {
      *
      * @param threshold Threshold is defined as a percentatge: 0.0f -> 1.0f
      */
-    Rectangle GetAlphaBorder(float threshold) const {
-        return ::GetImageAlphaBorder(*this, threshold);
-    }
+    Rectangle GetAlphaBorder(float threshold) const { return ::GetImageAlphaBorder(*this, threshold); }
 
     /**
      * Get image pixel color at (x, y) position
      */
-    raylib::Color GetColor(int x = 0, int y = 0) const {
-        return ::GetImageColor(*this, x, y);
-    }
+    raylib::Color GetColor(int x = 0, int y = 0) const { return ::GetImageColor(*this, x, y); }
 
     /**
      * Get image pixel color at vector position
@@ -620,8 +597,7 @@ class Image : public ::Image {
         ::ImageDrawPixelV(this, position, color);
     }
 
-    void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY,
-            ::Color color = {255, 255, 255, 255}) {
+    void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY, ::Color color = {255, 255, 255, 255}) {
         ::ImageDrawLine(this, startPosX, startPosY, endPosX, endPosY, color);
     }
 
@@ -629,23 +605,19 @@ class Image : public ::Image {
         ::ImageDrawLineV(this, start, end, color);
     }
 
-    void DrawCircle(int centerX, int centerY, int radius,
-            ::Color color = {255, 255, 255, 255}) {
+    void DrawCircle(int centerX, int centerY, int radius, ::Color color = {255, 255, 255, 255}) {
         ::ImageDrawCircle(this, centerX, centerY, radius, color);
     }
 
-    void DrawCircle(::Vector2 center, int radius,
-            ::Color color = {255, 255, 255, 255}) {
+    void DrawCircle(::Vector2 center, int radius, ::Color color = {255, 255, 255, 255}) {
         ::ImageDrawCircleV(this, center, radius, color);
     }
 
-    void DrawRectangle(int posX, int posY, int width, int height,
-            ::Color color = {255, 255, 255, 255}) {
+    void DrawRectangle(int posX, int posY, int width, int height, ::Color color = {255, 255, 255, 255}) {
         ::ImageDrawRectangle(this, posX, posY, width, height, color);
     }
 
-    void DrawRectangle(Vector2 position, Vector2 size,
-            ::Color color = {255, 255, 255, 255}) {
+    void DrawRectangle(Vector2 position, Vector2 size, ::Color color = {255, 255, 255, 255}) {
         ::ImageDrawRectangleV(this, position, size, color);
     }
 
@@ -653,29 +625,21 @@ class Image : public ::Image {
         ::ImageDrawRectangleRec(this, rec, color);
     }
 
-    void DrawRectangleLines(::Rectangle rec, int thick = 1,
-            ::Color color = {255, 255, 255, 255}) {
+    void DrawRectangleLines(::Rectangle rec, int thick = 1, ::Color color = {255, 255, 255, 255}) {
         ::ImageDrawRectangleLines(this, rec, thick, color);
     }
 
-    void Draw(const ::Image& src, ::Rectangle srcRec, ::Rectangle dstRec,
-            ::Color tint = {255, 255, 255, 255}) {
+    void Draw(const ::Image& src, ::Rectangle srcRec, ::Rectangle dstRec, ::Color tint = {255, 255, 255, 255}) {
         ::ImageDraw(this, src, srcRec, dstRec, tint);
     }
 
-    void DrawText(const char* text, ::Vector2 position, int fontSize,
-            ::Color color = {255, 255, 255, 255}) {
-        ::ImageDrawText(this,
-            text,
-            static_cast<int>(position.x),
-            static_cast<int>(position.y),
-            fontSize,
-            color);
+    void DrawText(const char* text, ::Vector2 position, int fontSize, ::Color color = {255, 255, 255, 255}) {
+        ::ImageDrawText(this, text, static_cast<int>(position.x), static_cast<int>(position.y), fontSize, color);
     }
 
-    void DrawText(const std::string& text, ::Vector2 position, int fontSize,
-            ::Color color = {255, 255, 255, 255}) {
-        ::ImageDrawText(this,
+    void DrawText(const std::string& text, ::Vector2 position, int fontSize, ::Color color = {255, 255, 255, 255}) {
+        ::ImageDrawText(
+            this,
             text.c_str(),
             static_cast<int>(position.x),
             static_cast<int>(position.y),
@@ -683,69 +647,67 @@ class Image : public ::Image {
             color);
     }
 
-    void DrawText(const std::string& text, int x, int y, int fontSize,
-            ::Color color = {255, 255, 255, 255}) {
+    void DrawText(const std::string& text, int x, int y, int fontSize, ::Color color = {255, 255, 255, 255}) {
         ::ImageDrawText(this, text.c_str(), x, y, fontSize, color);
     }
 
-    void DrawText(const char* text, int x, int y, int fontSize,
-            ::Color color = {255, 255, 255, 255}) {
+    void DrawText(const char* text, int x, int y, int fontSize, ::Color color = {255, 255, 255, 255}) {
         ::ImageDrawText(this, text, x, y, fontSize, color);
     }
 
-    void DrawText(const ::Font& font, const std::string& text, ::Vector2 position,
-            float fontSize, float spacing, ::Color tint = {255, 255, 255, 255}) {
+    void DrawText(
+        const ::Font& font,
+        const std::string& text,
+        ::Vector2 position,
+        float fontSize,
+        float spacing,
+        ::Color tint = {255, 255, 255, 255}) {
         ::ImageDrawTextEx(this, font, text.c_str(), position, fontSize, spacing, tint);
     }
 
-    void DrawText(const ::Font& font, const char* text, ::Vector2 position,
-            float fontSize, float spacing, ::Color tint = {255, 255, 255, 255}) {
+    void DrawText(
+        const ::Font& font,
+        const char* text,
+        ::Vector2 position,
+        float fontSize,
+        float spacing,
+        ::Color tint = {255, 255, 255, 255}) {
         ::ImageDrawTextEx(this, font, text, position, fontSize, spacing, tint);
     }
 
     /**
      * Load color data from image as a Color array (RGBA - 32bit)
      */
-    ::Color* LoadColors() const {
-        return ::LoadImageColors(*this);
-    }
+    ::Color* LoadColors() const { return ::LoadImageColors(*this); }
 
     /**
      * Load colors palette from image as a Color array (RGBA - 32bit)
      */
-    ::Color* LoadPalette(int maxPaletteSize, int *colorsCount) const {
+    ::Color* LoadPalette(int maxPaletteSize, int* colorsCount) const {
         return ::LoadImagePalette(*this, maxPaletteSize, colorsCount);
     }
 
     /**
      * Unload color data loaded with LoadImageColors()
      */
-    void UnloadColors(::Color* colors) const {
-        ::UnloadImageColors(colors);
-    }
+    void UnloadColors(::Color* colors) const { ::UnloadImageColors(colors); }
 
     /**
      * Unload colors palette loaded with LoadImagePalette()
      */
-    void UnloadPalette(::Color* colors) const {
-        ::UnloadImagePalette(colors);
-    }
+    void UnloadPalette(::Color* colors) const { ::UnloadImagePalette(colors); }
 
     /**
      * Load texture from image data.
      */
-    ::Texture2D LoadTexture() const {
-        return ::LoadTextureFromImage(*this);
-    }
+    ::Texture2D LoadTexture() const { return ::LoadTextureFromImage(*this); }
 
     /**
      * Loads a texture from the image data.
      *
      * @see LoadTexture()
      */
-    operator ::Texture2D() {
-        return LoadTexture();
-    }
+    operator ::Texture2D() { return LoadTexture(); }
 
     /**
      * Get pixel data size in bytes for certain format
@@ -759,20 +721,15 @@ class Image : public ::Image {
      *
      * @return The pixel data size of the image.
      */
-    int GetPixelDataSize() const {
-        return ::GetPixelDataSize(width, height, format);
-    }
+    int GetPixelDataSize() const { return ::GetPixelDataSize(width, height, format); }
 
     /**
      * Retrieve whether or not the Image has been loaded.
      *
      * @return True or false depending on whether the Image has been loaded.
      */
-    bool IsReady() const {
-        return ::IsImageReady(*this);
-    }
-
- protected:
+    bool IsReady() const { return ::IsImageReady(*this); }
+protected:
     void set(const ::Image& image) {
         data = image.data;
         width = image.width;
@@ -781,8 +738,8 @@ class Image : public ::Image {
         format = image.format;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RImage = raylib::Image;
 
-#endif  // RAYLIB_CPP_INCLUDE_IMAGE_HPP_
+#endif // RAYLIB_CPP_INCLUDE_IMAGE_HPP_

--- a/include/Keyboard.hpp
+++ b/include/Keyboard.hpp
@@ -8,57 +8,57 @@ namespace raylib {
  * Input-related functions: keyboard
  */
 namespace Keyboard {
-    /**
-     * Detect if a key has been pressed once
-     */
-    [[maybe_unused]] RLCPPAPI inline bool IsKeyPressed(int key) {
-        return ::IsKeyPressed(key);
-    }
+/**
+ * Detect if a key has been pressed once
+ */
+[[maybe_unused]] RLCPPAPI inline bool IsKeyPressed(int key) {
+    return ::IsKeyPressed(key);
+}
 
-    /**
-     * Detect if a key has been pressed again (Only PLATFORM_DESKTOP)
-     */
-    [[maybe_unused]] RLCPPAPI inline bool IsKeyPressedRepeat(int key) {
-        return ::IsKeyPressedRepeat(key);
-    }
+/**
+ * Detect if a key has been pressed again (Only PLATFORM_DESKTOP)
+ */
+[[maybe_unused]] RLCPPAPI inline bool IsKeyPressedRepeat(int key) {
+    return ::IsKeyPressedRepeat(key);
+}
 
-    /**
-     * Detect if a key is being pressed
-     */
-    [[maybe_unused]] RLCPPAPI inline bool IsKeyDown(int key) {
-        return ::IsKeyDown(key);
-    }
+/**
+ * Detect if a key is being pressed
+ */
+[[maybe_unused]] RLCPPAPI inline bool IsKeyDown(int key) {
+    return ::IsKeyDown(key);
+}
 
-    /**
-     * Detect if a key has been released once
-     */
-    [[maybe_unused]] RLCPPAPI inline bool IsKeyReleased(int key) {
-        return ::IsKeyReleased(key);
-    }
+/**
+ * Detect if a key has been released once
+ */
+[[maybe_unused]] RLCPPAPI inline bool IsKeyReleased(int key) {
+    return ::IsKeyReleased(key);
+}
 
-    /**
-     * Detect if a key is NOT being pressed
-     */
-    [[maybe_unused]] RLCPPAPI inline bool IsKeyUp(int key) {
-        return ::IsKeyUp(key);
-    }
+/**
+ * Detect if a key is NOT being pressed
+ */
+[[maybe_unused]] RLCPPAPI inline bool IsKeyUp(int key) {
+    return ::IsKeyUp(key);
+}
 
-    /**
-     * Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
-     */
+/**
+ * Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
+ */
 
-    [[maybe_unused]] RLCPPAPI inline int GetKeyPressed() {
-        return ::GetKeyPressed();
-    }
+[[maybe_unused]] RLCPPAPI inline int GetKeyPressed() {
+    return ::GetKeyPressed();
+}
 
-    /**
-     * Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
-     */
-    [[maybe_unused]] RLCPPAPI inline int GetCharPressed() {
-        return ::GetCharPressed();
-    }
-}  // namespace Keyboard
-}  // namespace raylib
+/**
+ * Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
+ */
+[[maybe_unused]] RLCPPAPI inline int GetCharPressed() {
+    return ::GetCharPressed();
+}
+} // namespace Keyboard
+} // namespace raylib
 namespace RKeyboard = raylib::Keyboard;
 
-#endif  // RAYLIB_CPP_INCLUDE_KEYBOARD_HPP_
+#endif // RAYLIB_CPP_INCLUDE_KEYBOARD_HPP_

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -4,25 +4,21 @@
 #include <string>
 #include <vector>
 
-#include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Material type (generic)
  */
 class Material : public ::Material {
- public:
-    Material(const ::Material& material) {
-        set(material);
-    }
+public:
+    Material(const ::Material& material) { set(material); }
 
     /**
      * Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
      */
-    Material() {
-        set(LoadMaterialDefault());
-    }
+    Material() { set(LoadMaterialDefault()); }
 
     Material(const Material&) = delete;
 
@@ -37,9 +33,7 @@ class Material : public ::Material {
         other.params[3] = 0.0f;
     }
 
-    ~Material() {
-        Unload();
-    }
+    ~Material() { Unload(); }
 
     /**
      * Load materials from model file
@@ -98,9 +92,7 @@ class Material : public ::Material {
     /**
      * Draw a 3d mesh with material and transform
      */
-    void DrawMesh(const ::Mesh& mesh, ::Matrix transform) const {
-        ::DrawMesh(mesh, *this, transform);
-    }
+    void DrawMesh(const ::Mesh& mesh, ::Matrix transform) const { ::DrawMesh(mesh, *this, transform); }
 
     /**
      * Draw multiple mesh instances with material and different transforms
@@ -112,11 +104,8 @@ class Material : public ::Material {
     /**
      * Check if material is ready
      */
-    bool IsReady() const {
-        return ::IsMaterialReady(*this);
-    }
-
- protected:
+    bool IsReady() const { return ::IsMaterialReady(*this); }
+protected:
     void set(const ::Material& material) {
         shader = material.shader;
         maps = material.maps;
@@ -126,8 +115,8 @@ class Material : public ::Material {
         params[3] = material.params[3];
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RMaterial = raylib::Material;
 
-#endif  // RAYLIB_CPP_INCLUDE_MATERIAL_HPP_
+#endif // RAYLIB_CPP_INCLUDE_MATERIAL_HPP_

--- a/include/Matrix.hpp
+++ b/include/Matrix.hpp
@@ -1,8 +1,8 @@
 #ifndef RAYLIB_CPP_INCLUDE_MATRIX_HPP_
 #define RAYLIB_CPP_INCLUDE_MATRIX_HPP_
 
-#include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 #include "./raymath.hpp"
 
 #ifndef RAYLIB_CPP_NO_MATH
@@ -14,25 +14,46 @@ namespace raylib {
  * Matrix type (OpenGL style 4x4 - right handed, column major)
  */
 class Matrix : public ::Matrix {
- public:
-    Matrix(const ::Matrix& mat) : ::Matrix{
-            mat.m0, mat.m4, mat.m8, mat.m12,
-            mat.m1, mat.m5, mat.m9, mat.m13,
-            mat.m2, mat.m6, mat.m10, mat.m14,
-            mat.m3, mat.m7, mat.m11, mat.m15} {
+public:
+    Matrix(const ::Matrix& mat)
+        : ::Matrix{
+              mat.m0,
+              mat.m4,
+              mat.m8,
+              mat.m12,
+              mat.m1,
+              mat.m5,
+              mat.m9,
+              mat.m13,
+              mat.m2,
+              mat.m6,
+              mat.m10,
+              mat.m14,
+              mat.m3,
+              mat.m7,
+              mat.m11,
+              mat.m15} {
         // Nothing.
     }
 
     Matrix(
-            float m0 = 0, float m4 = 0, float m8 = 0, float m12 = 0,
-            float m1 = 0, float m5 = 0, float m9 = 0, float m13 = 0,
-            float m2 = 0, float m6 = 0, float m10 = 0, float m14 = 0,
-            float m3 = 0, float m7 = 0, float m11 = 0, float m15 = 0) :
-        ::Matrix{
-            m0, m4, m8, m12,
-            m1, m5, m9, m13,
-            m2, m6, m10, m14,
-            m3, m7, m11, m15} {
+        float m0 = 0,
+        float m4 = 0,
+        float m8 = 0,
+        float m12 = 0,
+        float m1 = 0,
+        float m5 = 0,
+        float m9 = 0,
+        float m13 = 0,
+        float m2 = 0,
+        float m6 = 0,
+        float m10 = 0,
+        float m14 = 0,
+        float m3 = 0,
+        float m7 = 0,
+        float m11 = 0,
+        float m15 = 0)
+        : ::Matrix{m0, m4, m8, m12, m1, m5, m9, m13, m2, m6, m10, m14, m3, m7, m11, m15} {
         // Nothing.
     }
 
@@ -64,105 +85,56 @@ class Matrix : public ::Matrix {
     }
 
     bool operator==(const ::Matrix& other) {
-        return m0 == other.m0
-            && m1 == other.m1
-            && m2 == other.m2
-            && m3 == other.m3
-            && m4 == other.m4
-            && m5 == other.m5
-            && m6 == other.m6
-            && m7 == other.m7
-            && m8 == other.m8
-            && m9 == other.m9
-            && m10 == other.m10
-            && m11 == other.m11
-            && m12 == other.m12
-            && m13 == other.m13
-            && m14 == other.m14
-            && m15 == other.m15;
+        return m0 == other.m0 && m1 == other.m1 && m2 == other.m2 && m3 == other.m3 && m4 == other.m4 &&
+               m5 == other.m5 && m6 == other.m6 && m7 == other.m7 && m8 == other.m8 && m9 == other.m9 &&
+               m10 == other.m10 && m11 == other.m11 && m12 == other.m12 && m13 == other.m13 && m14 == other.m14 &&
+               m15 == other.m15;
     }
 
-    bool operator!=(const ::Matrix& other) {
-        return !(*this == other);
-    }
+    bool operator!=(const ::Matrix& other) { return !(*this == other); }
 
 #ifndef RAYLIB_CPP_NO_MATH
     /**
      * Returns the trace of the matrix (sum of the values along the diagonal)
      */
-    float Trace() const {
-        return ::MatrixTrace(*this);
-    }
+    float Trace() const { return ::MatrixTrace(*this); }
 
     /**
      * Transposes provided matrix
      */
-    Matrix Transpose() const {
-        return ::MatrixTranspose(*this);
-    }
+    Matrix Transpose() const { return ::MatrixTranspose(*this); }
 
-    Matrix Invert() const {
-        return ::MatrixInvert(*this);
-    }
+    Matrix Invert() const { return ::MatrixInvert(*this); }
 
-    static Matrix Identity() {
-        return ::MatrixIdentity();
-    }
+    static Matrix Identity() { return ::MatrixIdentity(); }
 
-    Matrix Add(const ::Matrix& right) {
-        return ::MatrixAdd(*this, right);
-    }
+    Matrix Add(const ::Matrix& right) { return ::MatrixAdd(*this, right); }
 
-    Matrix operator+(const ::Matrix& matrix) {
-            return ::MatrixAdd(*this, matrix);
-    }
+    Matrix operator+(const ::Matrix& matrix) { return ::MatrixAdd(*this, matrix); }
 
-    Matrix Subtract(const ::Matrix& right) {
-        return ::MatrixSubtract(*this, right);
-    }
+    Matrix Subtract(const ::Matrix& right) { return ::MatrixSubtract(*this, right); }
 
-    Matrix operator-(const ::Matrix& matrix) {
-        return ::MatrixSubtract(*this, matrix);
-    }
+    Matrix operator-(const ::Matrix& matrix) { return ::MatrixSubtract(*this, matrix); }
 
-    static Matrix Translate(float x, float y, float z) {
-        return ::MatrixTranslate(x, y, z);
-    }
+    static Matrix Translate(float x, float y, float z) { return ::MatrixTranslate(x, y, z); }
 
-    static Matrix Rotate(Vector3 axis, float angle) {
-        return ::MatrixRotate(axis, angle);
-    }
+    static Matrix Rotate(Vector3 axis, float angle) { return ::MatrixRotate(axis, angle); }
 
-    static Matrix RotateXYZ(Vector3 angle) {
-        return ::MatrixRotateXYZ(angle);
-    }
+    static Matrix RotateXYZ(Vector3 angle) { return ::MatrixRotateXYZ(angle); }
 
-    static Matrix RotateX(float angle) {
-        return ::MatrixRotateX(angle);
-    }
+    static Matrix RotateX(float angle) { return ::MatrixRotateX(angle); }
 
-    static Matrix RotateY(float angle) {
-        return ::MatrixRotateY(angle);
-    }
+    static Matrix RotateY(float angle) { return ::MatrixRotateY(angle); }
 
-    static Matrix RotateZ(float angle) {
-        return ::MatrixRotateZ(angle);
-    }
+    static Matrix RotateZ(float angle) { return ::MatrixRotateZ(angle); }
 
-    static Matrix Scale(float x, float y, float z) {
-        return ::MatrixScale(x, y, z);
-    }
+    static Matrix Scale(float x, float y, float z) { return ::MatrixScale(x, y, z); }
 
-    Matrix Multiply(const ::Matrix& right) const {
-        return ::MatrixMultiply(*this, right);
-    }
+    Matrix Multiply(const ::Matrix& right) const { return ::MatrixMultiply(*this, right); }
 
-    Matrix operator*(const ::Matrix& matrix) {
-        return ::MatrixMultiply(*this, matrix);
-    }
+    Matrix operator*(const ::Matrix& matrix) { return ::MatrixMultiply(*this, matrix); }
 
-    static Matrix Frustum(double left, double right, double bottom, double top,
-            double near, double far) {
+    static Matrix Frustum(double left, double right, double bottom, double top, double near, double far) {
         return ::MatrixFrustum(left, right, bottom, top, near, far);
     }
 
@@ -170,22 +142,15 @@ class Matrix : public ::Matrix {
         return ::MatrixPerspective(fovy, aspect, near, far);
     }
 
-    static Matrix Ortho(double left, double right, double bottom, double top,
-            double near, double far) {
+    static Matrix Ortho(double left, double right, double bottom, double top, double near, double far) {
         return ::MatrixOrtho(left, right, bottom, top, near, far);
     }
 
-    static Matrix LookAt(Vector3 eye, Vector3 target, Vector3 up) {
-        return ::MatrixLookAt(eye, target, up);
-    }
+    static Matrix LookAt(Vector3 eye, Vector3 target, Vector3 up) { return ::MatrixLookAt(eye, target, up); }
 
-    float16 ToFloatV() const {
-        return ::MatrixToFloatV(*this);
-    }
+    float16 ToFloatV() const { return ::MatrixToFloatV(*this); }
 
-    operator float16() {
-        return ToFloatV();
-    }
+    operator float16() { return ToFloatV(); }
 
     /**
      * Set shader uniform value (matrix 4x4)
@@ -195,17 +160,12 @@ class Matrix : public ::Matrix {
         return *this;
     }
 
-    static Matrix GetCamera(const ::Camera& camera) {
-        return ::GetCameraMatrix(camera);
-    }
+    static Matrix GetCamera(const ::Camera& camera) { return ::GetCameraMatrix(camera); }
 
-    static Matrix GetCamera(const ::Camera2D& camera) {
-        return ::GetCameraMatrix2D(camera);
-    }
+    static Matrix GetCamera(const ::Camera2D& camera) { return ::GetCameraMatrix2D(camera); }
 
 #endif
-
- protected:
+protected:
     void set(const ::Matrix& mat) {
         m0 = mat.m0;
         m1 = mat.m1;
@@ -225,8 +185,8 @@ class Matrix : public ::Matrix {
         m15 = mat.m15;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RMatrix = raylib::Matrix;
 
-#endif  // RAYLIB_CPP_INCLUDE_MATRIX_HPP_
+#endif // RAYLIB_CPP_INCLUDE_MATRIX_HPP_

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -4,11 +4,11 @@
 #include <string>
 #include <vector>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./BoundingBox.hpp"
-#include "./Model.hpp"
 #include "./MeshUnmanaged.hpp"
+#include "./Model.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
@@ -19,7 +19,7 @@ namespace raylib {
  * @see raylib::MeshUnmanaged
  */
 class Mesh : public MeshUnmanaged {
- public:
+public:
     using MeshUnmanaged::MeshUnmanaged;
 
     /**
@@ -82,12 +82,10 @@ class Mesh : public MeshUnmanaged {
         return *this;
     }
 
-    ~Mesh() {
-        Unload();
-    }
+    ~Mesh() { Unload(); }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RMesh = raylib::Mesh;
 
-#endif  // RAYLIB_CPP_INCLUDE_MESH_HPP_
+#endif // RAYLIB_CPP_INCLUDE_MESH_HPP_

--- a/include/MeshUnmanaged.hpp
+++ b/include/MeshUnmanaged.hpp
@@ -4,10 +4,10 @@
 #include <string>
 #include <vector>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./BoundingBox.hpp"
 #include "./Model.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 
@@ -19,7 +19,7 @@ namespace raylib {
  * @see raylib::Mesh
  */
 class MeshUnmanaged : public ::Mesh {
- public:
+public:
     /**
      * Default texture constructor.
      */
@@ -41,13 +41,9 @@ class MeshUnmanaged : public ::Mesh {
         vboId = nullptr;
     }
 
-    MeshUnmanaged(const ::Mesh& mesh) {
-        set(mesh);
-    }
+    MeshUnmanaged(const ::Mesh& mesh) { set(mesh); }
 
-    MeshUnmanaged(::Mesh&& mesh) {
-        set(mesh);
-    }
+    MeshUnmanaged(::Mesh&& mesh) { set(mesh); }
 
     /**
      * Load meshes from model file
@@ -61,9 +57,7 @@ class MeshUnmanaged : public ::Mesh {
     /**
      * Generate polygonal mesh
      */
-    static ::Mesh Poly(int sides, float radius) {
-        return ::GenMeshPoly(sides, radius);
-    }
+    static ::Mesh Poly(int sides, float radius) { return ::GenMeshPoly(sides, radius); }
 
     /**
      * Generate plane mesh (with subdivisions)
@@ -75,37 +69,27 @@ class MeshUnmanaged : public ::Mesh {
     /**
      * Generate cuboid mesh
      */
-    static ::Mesh Cube(float width, float height, float length) {
-        return ::GenMeshCube(width, height, length);
-    }
+    static ::Mesh Cube(float width, float height, float length) { return ::GenMeshCube(width, height, length); }
 
     /**
      * Generate sphere mesh (standard sphere)
      */
-    static ::Mesh Sphere(float radius, int rings, int slices) {
-        return ::GenMeshSphere(radius, rings, slices);
-    }
+    static ::Mesh Sphere(float radius, int rings, int slices) { return ::GenMeshSphere(radius, rings, slices); }
 
     /**
      * Generate half-sphere mesh (no bottom cap)
      */
-    static ::Mesh HemiSphere(float radius, int rings, int slices) {
-        return ::GenMeshHemiSphere(radius, rings, slices);
-    }
+    static ::Mesh HemiSphere(float radius, int rings, int slices) { return ::GenMeshHemiSphere(radius, rings, slices); }
 
     /**
      * Generate cylinder mesh
      */
-    static ::Mesh Cylinder(float radius, float height, int slices) {
-        return ::GenMeshCylinder(radius, height, slices);
-    }
+    static ::Mesh Cylinder(float radius, float height, int slices) { return ::GenMeshCylinder(radius, height, slices); }
 
     /**
      * Generate cone/pyramid mesh
      */
-    static ::Mesh Cone(float radius, float height, int slices) {
-        return ::GenMeshCone(radius, height, slices);
-    }
+    static ::Mesh Cone(float radius, float height, int slices) { return ::GenMeshCone(radius, height, slices); }
 
     /**
      * Generate torus mesh
@@ -124,9 +108,7 @@ class MeshUnmanaged : public ::Mesh {
     /**
      * Generate heightmap mesh from image data
      */
-    static ::Mesh Heightmap(const ::Image& heightmap, ::Vector3 size) {
-        return ::GenMeshHeightmap(heightmap, size);
-    }
+    static ::Mesh Heightmap(const ::Image& heightmap, ::Vector3 size) { return ::GenMeshHeightmap(heightmap, size); }
 
     /**
      * Generate cubes-based map mesh from image data
@@ -138,18 +120,18 @@ class MeshUnmanaged : public ::Mesh {
     GETTERSETTER(int, VertexCount, vertexCount)
     GETTERSETTER(int, TriangleCount, triangleCount)
     GETTERSETTER(float*, Vertices, vertices)
-    GETTERSETTER(float *, TexCoords, texcoords)
-    GETTERSETTER(float *, TexCoords2, texcoords2)
-    GETTERSETTER(float *, Normals, normals)
-    GETTERSETTER(float *, Tangents, tangents)
-    GETTERSETTER(unsigned char *, Colors, colors)
-    GETTERSETTER(unsigned short *, Indices, indices) // NOLINT
-    GETTERSETTER(float *, AnimVertices, animVertices)
-    GETTERSETTER(float *, AnimNormals, animNormals)
-    GETTERSETTER(unsigned char *, BoneIds, boneIds)
-    GETTERSETTER(float *, BoneWeights, boneWeights)
+    GETTERSETTER(float*, TexCoords, texcoords)
+    GETTERSETTER(float*, TexCoords2, texcoords2)
+    GETTERSETTER(float*, Normals, normals)
+    GETTERSETTER(float*, Tangents, tangents)
+    GETTERSETTER(unsigned char*, Colors, colors)
+    GETTERSETTER(unsigned short*, Indices, indices) // NOLINT
+    GETTERSETTER(float*, AnimVertices, animVertices)
+    GETTERSETTER(float*, AnimNormals, animNormals)
+    GETTERSETTER(unsigned char*, BoneIds, boneIds)
+    GETTERSETTER(float*, BoneWeights, boneWeights)
     GETTERSETTER(unsigned int, VaoId, vaoId)
-    GETTERSETTER(unsigned int *, VboId, vboId)
+    GETTERSETTER(unsigned int*, VboId, vboId)
 
     MeshUnmanaged& operator=(const ::Mesh& mesh) {
         set(mesh);
@@ -169,23 +151,19 @@ class MeshUnmanaged : public ::Mesh {
     /**
      * Upload mesh vertex data to GPU (VRAM)
      */
-    void Upload(bool dynamic = false) {
-        ::UploadMesh(this, dynamic);
-    }
+    void Upload(bool dynamic = false) { ::UploadMesh(this, dynamic); }
 
     /**
      * Upload mesh vertex data to GPU (VRAM)
      */
-    void UpdateBuffer(int index, void *data, int dataSize, int offset = 0) {
+    void UpdateBuffer(int index, void* data, int dataSize, int offset = 0) {
         ::UpdateMeshBuffer(*this, index, data, dataSize, offset);
     }
 
     /**
      * Draw a 3d mesh with material and transform
      */
-    void Draw(const ::Material& material, const ::Matrix& transform) const {
-        ::DrawMesh(*this, material, transform);
-    }
+    void Draw(const ::Material& material, const ::Matrix& transform) const { ::DrawMesh(*this, material, transform); }
 
     /**
      * Draw multiple mesh instances with material and different transforms
@@ -208,16 +186,12 @@ class MeshUnmanaged : public ::Mesh {
     /**
      * Compute mesh bounding box limits
      */
-    raylib::BoundingBox BoundingBox() const {
-        return ::GetMeshBoundingBox(*this);
-    }
+    raylib::BoundingBox BoundingBox() const { return ::GetMeshBoundingBox(*this); }
 
     /**
      * Compute mesh bounding box limits
      */
-    operator raylib::BoundingBox() {
-        return BoundingBox();
-    }
+    operator raylib::BoundingBox() { return BoundingBox(); }
 
     /**
      * Compute mesh tangents
@@ -230,18 +204,13 @@ class MeshUnmanaged : public ::Mesh {
     /**
      * Load model from generated mesh
      */
-    raylib::Model LoadModelFrom() const {
-        return ::LoadModelFromMesh(*this);
-    }
+    raylib::Model LoadModelFrom() const { return ::LoadModelFromMesh(*this); }
 
     /**
      * Load model from generated mesh
      */
-    operator raylib::Model() {
-        return ::LoadModelFromMesh(*this);
-    }
-
- protected:
+    operator raylib::Model() { return ::LoadModelFromMesh(*this); }
+protected:
     void set(const ::Mesh& mesh) {
         vertexCount = mesh.vertexCount;
         triangleCount = mesh.triangleCount;
@@ -260,8 +229,8 @@ class MeshUnmanaged : public ::Mesh {
         vboId = mesh.vboId;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RMeshUnmanaged = raylib::MeshUnmanaged;
 
-#endif  // RAYLIB_CPP_INCLUDE_MESHUNMANAGED_HPP_
+#endif // RAYLIB_CPP_INCLUDE_MESHUNMANAGED_HPP_

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -3,9 +3,9 @@
 
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 class Mesh;
@@ -13,7 +13,7 @@ class Mesh;
  * Model type
  */
 class Model : public ::Model {
- public:
+public:
     Model() {
         // Nothing.
     }
@@ -21,27 +21,21 @@ class Model : public ::Model {
     /*
      * Copy a model from another model.
      */
-    Model(const ::Model& model) {
-        set(model);
-    }
+    Model(const ::Model& model) { set(model); }
 
     /*
      * Load a model from a file.
      *
      * @throws raylib::RaylibException Throws if failed to load the Modal.
      */
-    Model(const std::string& fileName) {
-        Load(fileName);
-    }
+    Model(const std::string& fileName) { Load(fileName); }
 
     /*
      * Load a model from a mesh.
      *
      * @throws raylib::RaylibException Throws if failed to load the Modal.
      */
-    Model(const ::Mesh& mesh) {
-        Load(mesh);
-    }
+    Model(const ::Mesh& mesh) { Load(mesh); }
 
     /**
      * The Model constructor with a Mesh() is removed.
@@ -52,9 +46,7 @@ class Model : public ::Model {
      */
     Model(const raylib::Mesh& mesh) = delete;
 
-    ~Model() {
-        Unload();
-    }
+    ~Model() { Unload(); }
 
     Model(const Model&) = delete;
 
@@ -138,16 +130,12 @@ class Model : public ::Model {
     /**
      * Check model animation skeleton match
      */
-    bool IsModelAnimationValid(const ::ModelAnimation& anim) const {
-        return ::IsModelAnimationValid(*this, anim);
-    }
+    bool IsModelAnimationValid(const ::ModelAnimation& anim) const { return ::IsModelAnimationValid(*this, anim); }
 
     /**
      * Draw a model (with texture if set)
      */
-    void Draw(::Vector3 position,
-            float scale = 1.0f,
-            ::Color tint = {255, 255, 255, 255}) const {
+    void Draw(::Vector3 position, float scale = 1.0f, ::Color tint = {255, 255, 255, 255}) const {
         ::DrawModel(*this, position, scale, tint);
     }
 
@@ -155,20 +143,18 @@ class Model : public ::Model {
      * Draw a model with extended parameters
      */
     void Draw(
-            ::Vector3 position,
-            ::Vector3 rotationAxis,
-            float rotationAngle = 0.0f,
-            ::Vector3 scale = {1.0f, 1.0f, 1.0f},
-            ::Color tint = {255, 255, 255, 255}) const {
+        ::Vector3 position,
+        ::Vector3 rotationAxis,
+        float rotationAngle = 0.0f,
+        ::Vector3 scale = {1.0f, 1.0f, 1.0f},
+        ::Color tint = {255, 255, 255, 255}) const {
         ::DrawModelEx(*this, position, rotationAxis, rotationAngle, scale, tint);
     }
 
     /**
      * Draw a model wires (with texture if set)
      */
-    void DrawWires(::Vector3 position,
-            float scale = 1.0f,
-            ::Color tint = {255, 255, 255, 255}) const {
+    void DrawWires(::Vector3 position, float scale = 1.0f, ::Color tint = {255, 255, 255, 255}) const {
         ::DrawModelWires(*this, position, scale, tint);
     }
 
@@ -176,34 +162,28 @@ class Model : public ::Model {
      * Draw a model wires (with texture if set) with extended parameters
      */
     void DrawWires(
-            ::Vector3 position,
-            ::Vector3 rotationAxis,
-            float rotationAngle = 0.0f,
-            ::Vector3 scale = {1.0f, 1.0f, 1.0f},
-            ::Color tint = {255, 255, 255, 255}) const {
+        ::Vector3 position,
+        ::Vector3 rotationAxis,
+        float rotationAngle = 0.0f,
+        ::Vector3 scale = {1.0f, 1.0f, 1.0f},
+        ::Color tint = {255, 255, 255, 255}) const {
         ::DrawModelWiresEx(*this, position, rotationAxis, rotationAngle, scale, tint);
     }
 
     /**
      * Compute model bounding box limits (considers all meshes)
      */
-    BoundingBox GetBoundingBox() const {
-        return ::GetModelBoundingBox(*this);
-    }
+    BoundingBox GetBoundingBox() const { return ::GetModelBoundingBox(*this); }
 
     /**
      * Compute model bounding box limits (considers all meshes)
      */
-    operator BoundingBox() const {
-        return ::GetModelBoundingBox(*this);
-    }
+    operator BoundingBox() const { return ::GetModelBoundingBox(*this); }
 
     /**
      * Determines whether or not the Model has data in it.
      */
-    bool IsReady() const {
-        return ::IsModelReady(*this);
-    }
+    bool IsReady() const { return ::IsModelReady(*this); }
 
     /**
      * Loads a Model from the given file.
@@ -228,8 +208,7 @@ class Model : public ::Model {
             throw RaylibException("Failed to load Model from Mesh");
         }
     }
-
- protected:
+protected:
     void set(const ::Model& model) {
         transform = model.transform;
 
@@ -245,8 +224,8 @@ class Model : public ::Model {
     }
 };
 
-}  // namespace raylib
+} // namespace raylib
 
 using RModel = raylib::Model;
 
-#endif  // RAYLIB_CPP_INCLUDE_MODEL_HPP_
+#endif // RAYLIB_CPP_INCLUDE_MODEL_HPP_

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -1,22 +1,20 @@
 #ifndef RAYLIB_CPP_INCLUDE_MODELANIMATION_HPP_
 #define RAYLIB_CPP_INCLUDE_MODELANIMATION_HPP_
 
-#include <vector>
 #include <string>
+#include <vector>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./Mesh.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Model animation
  */
 class ModelAnimation : public ::ModelAnimation {
- public:
-    ModelAnimation(const ::ModelAnimation& model) {
-        set(model);
-    }
+public:
+    ModelAnimation(const ::ModelAnimation& model) { set(model); }
 
     ModelAnimation(const ModelAnimation&) = delete;
 
@@ -29,9 +27,7 @@ class ModelAnimation : public ::ModelAnimation {
         other.framePoses = nullptr;
     }
 
-    ~ModelAnimation() {
-        Unload();
-    }
+    ~ModelAnimation() { Unload(); }
 
     /**
      * Load model animations from file
@@ -77,9 +73,7 @@ class ModelAnimation : public ::ModelAnimation {
     /**
      * Unload animation data
      */
-    void Unload() {
-        ::UnloadModelAnimation(*this);
-    }
+    void Unload() { ::UnloadModelAnimation(*this); }
 
     /**
      * Update model animation pose
@@ -92,11 +86,8 @@ class ModelAnimation : public ::ModelAnimation {
     /**
      * Check model animation skeleton match
      */
-    bool IsValid(const ::Model& model) const {
-        return ::IsModelAnimationValid(model, *this);
-    }
-
- protected:
+    bool IsValid(const ::Model& model) const { return ::IsModelAnimationValid(model, *this); }
+protected:
     void set(const ::ModelAnimation& model) {
         boneCount = model.boneCount;
         frameCount = model.frameCount;
@@ -109,8 +100,8 @@ class ModelAnimation : public ::ModelAnimation {
         }
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RModelAnimation = raylib::ModelAnimation;
 
-#endif  // RAYLIB_CPP_INCLUDE_MODELANIMATION_HPP_
+#endif // RAYLIB_CPP_INCLUDE_MODELANIMATION_HPP_

--- a/include/Mouse.hpp
+++ b/include/Mouse.hpp
@@ -1,152 +1,152 @@
 #ifndef RAYLIB_CPP_INCLUDE_MOUSE_HPP_
 #define RAYLIB_CPP_INCLUDE_MOUSE_HPP_
 
-#include "./raylib.hpp"
 #include "./Vector2.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Input-related functions: mouse
  */
 namespace Mouse {
-    /**
-     * Detect if a mouse button has been pressed once
-     */
-    [[maybe_unused]] RLCPPAPI inline bool IsButtonPressed(int button) {
-        return ::IsMouseButtonPressed(button);
-    }
+/**
+ * Detect if a mouse button has been pressed once
+ */
+[[maybe_unused]] RLCPPAPI inline bool IsButtonPressed(int button) {
+    return ::IsMouseButtonPressed(button);
+}
 
-    /**
-     * Detect if a mouse button is being pressed
-     */
-    [[maybe_unused]] RLCPPAPI inline bool IsButtonDown(int button) {
-        return ::IsMouseButtonDown(button);
-    }
+/**
+ * Detect if a mouse button is being pressed
+ */
+[[maybe_unused]] RLCPPAPI inline bool IsButtonDown(int button) {
+    return ::IsMouseButtonDown(button);
+}
 
-    /**
-     * Detect if a mouse button has been released once
-     */
-    [[maybe_unused]] RLCPPAPI inline bool IsButtonReleased(int button) {
-        return ::IsMouseButtonReleased(button);
-    }
+/**
+ * Detect if a mouse button has been released once
+ */
+[[maybe_unused]] RLCPPAPI inline bool IsButtonReleased(int button) {
+    return ::IsMouseButtonReleased(button);
+}
 
-    [[maybe_unused]] RLCPPAPI inline bool IsButtonUp(int button) {
-        return ::IsMouseButtonUp(button);
-    }
+[[maybe_unused]] RLCPPAPI inline bool IsButtonUp(int button) {
+    return ::IsMouseButtonUp(button);
+}
 
-    [[maybe_unused]] RLCPPAPI inline int GetX() {
-        return ::GetMouseX();
-    }
+[[maybe_unused]] RLCPPAPI inline int GetX() {
+    return ::GetMouseX();
+}
 
-    [[maybe_unused]] RLCPPAPI inline int GetY() {
-        return ::GetMouseY();
-    }
+[[maybe_unused]] RLCPPAPI inline int GetY() {
+    return ::GetMouseY();
+}
 
-    [[maybe_unused]] RLCPPAPI inline void SetX(int x) {
-        ::SetMousePosition(x, GetY());
-    }
+[[maybe_unused]] RLCPPAPI inline void SetX(int x) {
+    ::SetMousePosition(x, GetY());
+}
 
-    [[maybe_unused]] RLCPPAPI inline void SetY(int y) {
-        ::SetMousePosition(GetX(), y);
-    }
+[[maybe_unused]] RLCPPAPI inline void SetY(int y) {
+    ::SetMousePosition(GetX(), y);
+}
 
-    [[maybe_unused]] RLCPPAPI inline Vector2 GetPosition() {
-        return ::GetMousePosition();
-    }
+[[maybe_unused]] RLCPPAPI inline Vector2 GetPosition() {
+    return ::GetMousePosition();
+}
 
-    [[maybe_unused]] RLCPPAPI inline void SetPosition(int x, int y) {
-        ::SetMousePosition(x, y);
-    }
+[[maybe_unused]] RLCPPAPI inline void SetPosition(int x, int y) {
+    ::SetMousePosition(x, y);
+}
 
-    [[maybe_unused]] RLCPPAPI inline void SetPosition(::Vector2 position) {
-        ::SetMousePosition(static_cast<int>(position.x), static_cast<int>(position.y));
-    }
+[[maybe_unused]] RLCPPAPI inline void SetPosition(::Vector2 position) {
+    ::SetMousePosition(static_cast<int>(position.x), static_cast<int>(position.y));
+}
 
-    /**
-     * Get mouse delta between frames
-     */
-    [[maybe_unused]] RLCPPAPI inline Vector2 GetDelta() {
-        return ::GetMouseDelta();
-    }
+/**
+ * Get mouse delta between frames
+ */
+[[maybe_unused]] RLCPPAPI inline Vector2 GetDelta() {
+    return ::GetMouseDelta();
+}
 
-    [[maybe_unused]] RLCPPAPI inline void SetOffset(int offsetX = 0, int offsetY = 0) {
-        ::SetMouseOffset(offsetX, offsetY);
-    }
+[[maybe_unused]] RLCPPAPI inline void SetOffset(int offsetX = 0, int offsetY = 0) {
+    ::SetMouseOffset(offsetX, offsetY);
+}
 
-    [[maybe_unused]] RLCPPAPI inline void SetOffset(::Vector2 offset) {
-        ::SetMouseOffset(static_cast<int>(offset.x), static_cast<int>(offset.y));
-    }
+[[maybe_unused]] RLCPPAPI inline void SetOffset(::Vector2 offset) {
+    ::SetMouseOffset(static_cast<int>(offset.x), static_cast<int>(offset.y));
+}
 
-    [[maybe_unused]] RLCPPAPI inline void SetScale(float scaleX = 1.0f, float scaleY = 1.0f) {
-        ::SetMouseScale(scaleX, scaleY);
-    }
+[[maybe_unused]] RLCPPAPI inline void SetScale(float scaleX = 1.0f, float scaleY = 1.0f) {
+    ::SetMouseScale(scaleX, scaleY);
+}
 
-    [[maybe_unused]] RLCPPAPI inline void SetScale(::Vector2 scale) {
-        ::SetMouseScale(scale.x, scale.y);
-    }
+[[maybe_unused]] RLCPPAPI inline void SetScale(::Vector2 scale) {
+    ::SetMouseScale(scale.x, scale.y);
+}
 
-    /**
-     * Get mouse wheel movement for X or Y, whichever is larger
-     */
-    [[maybe_unused]] RLCPPAPI inline float GetWheelMove() {
-        return ::GetMouseWheelMove();
-    }
+/**
+ * Get mouse wheel movement for X or Y, whichever is larger
+ */
+[[maybe_unused]] RLCPPAPI inline float GetWheelMove() {
+    return ::GetMouseWheelMove();
+}
 
-    /**
-     * Get mouse wheel movement for both X and Y
-     *
-     * @see ::GetMouseWheelMoveV()
-     */
-    [[maybe_unused]] RLCPPAPI inline Vector2 GetWheelMoveV() {
-        return GetMouseWheelMoveV();
-    }
+/**
+ * Get mouse wheel movement for both X and Y
+ *
+ * @see ::GetMouseWheelMoveV()
+ */
+[[maybe_unused]] RLCPPAPI inline Vector2 GetWheelMoveV() {
+    return GetMouseWheelMoveV();
+}
 
-    /**
-     * Sets the current mouse cursor icon.
-     *
-     * @see ::MouseCursor
-     */
-    [[maybe_unused]] RLCPPAPI inline void SetCursor(int cursor = MOUSE_CURSOR_DEFAULT) {
-        ::SetMouseCursor(cursor);
-    }
+/**
+ * Sets the current mouse cursor icon.
+ *
+ * @see ::MouseCursor
+ */
+[[maybe_unused]] RLCPPAPI inline void SetCursor(int cursor = MOUSE_CURSOR_DEFAULT) {
+    ::SetMouseCursor(cursor);
+}
 
-    /**
-     * Get touch position X for touch point 0 (relative to screen size)
-     */
-    [[maybe_unused]] RLCPPAPI inline int GetTouchX() {
-        return ::GetTouchX();
-    }
+/**
+ * Get touch position X for touch point 0 (relative to screen size)
+ */
+[[maybe_unused]] RLCPPAPI inline int GetTouchX() {
+    return ::GetTouchX();
+}
 
-    /**
-     * Get touch position Y for touch point 0 (relative to screen size)
-     */
-    [[maybe_unused]] RLCPPAPI inline int GetTouchY() {
-        return ::GetTouchY();
-    }
+/**
+ * Get touch position Y for touch point 0 (relative to screen size)
+ */
+[[maybe_unused]] RLCPPAPI inline int GetTouchY() {
+    return ::GetTouchY();
+}
 
-    /**
-     * Get touch position XY for a touch point index (relative to screen size)
-     */
-    [[maybe_unused]] RLCPPAPI inline Vector2 GetTouchPosition(int index) {
-        return ::GetTouchPosition(index);
-    }
+/**
+ * Get touch position XY for a touch point index (relative to screen size)
+ */
+[[maybe_unused]] RLCPPAPI inline Vector2 GetTouchPosition(int index) {
+    return ::GetTouchPosition(index);
+}
 
-    /**
-     * Get a ray trace from mouse position
-     */
-    [[maybe_unused]] RLCPPAPI inline Ray GetRay(::Vector2 mousePosition, const ::Camera& camera) {
-        return ::GetMouseRay(mousePosition, camera);
-    }
+/**
+ * Get a ray trace from mouse position
+ */
+[[maybe_unused]] RLCPPAPI inline Ray GetRay(::Vector2 mousePosition, const ::Camera& camera) {
+    return ::GetMouseRay(mousePosition, camera);
+}
 
-    /**
-     * Get a ray trace from mouse position
-     */
-    [[maybe_unused]] RLCPPAPI inline Ray GetRay(const ::Camera& camera) {
-        return ::GetMouseRay(::GetMousePosition(), camera);
-    }
-}  // namespace Mouse
-}  // namespace raylib
+/**
+ * Get a ray trace from mouse position
+ */
+[[maybe_unused]] RLCPPAPI inline Ray GetRay(const ::Camera& camera) {
+    return ::GetMouseRay(::GetMousePosition(), camera);
+}
+} // namespace Mouse
+} // namespace raylib
 
 namespace RMouse = raylib::Mouse;
 
-#endif  // RAYLIB_CPP_INCLUDE_MOUSE_HPP_
+#endif // RAYLIB_CPP_INCLUDE_MOUSE_HPP_

--- a/include/Music.hpp
+++ b/include/Music.hpp
@@ -3,43 +3,39 @@
 
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Music stream type (audio file streaming from memory)
  */
 class Music : public ::Music {
- public:
-    Music(::AudioStream stream = {nullptr, nullptr, 0, 0, 0},
-            unsigned int frameCount = 0,
-            bool looping = false,
-            int ctxType = 0,
-            void *ctxData = nullptr) : ::Music{stream, frameCount, looping, ctxType, ctxData} {}
+public:
+    Music(
+        ::AudioStream stream = {nullptr, nullptr, 0, 0, 0},
+        unsigned int frameCount = 0,
+        bool looping = false,
+        int ctxType = 0,
+        void* ctxData = nullptr)
+        : ::Music{stream, frameCount, looping, ctxType, ctxData} {}
 
-    Music(const ::Music& music) {
-        set(music);
-    }
+    Music(const ::Music& music) { set(music); }
 
     /**
      * Load music stream from file
      *
      * @throws raylib::RaylibException Throws if the music failed to load.
      */
-    Music(const std::string& fileName) {
-        Load(fileName);
-    }
+    Music(const std::string& fileName) { Load(fileName); }
 
     /**
      * Load music stream from memory
      *
      * @throws raylib::RaylibException Throws if the music failed to load.
      */
-    Music(const std::string& fileType, unsigned char* data, int dataSize) {
-        Load(fileType, data, dataSize);
-    }
+    Music(const std::string& fileType, unsigned char* data, int dataSize) { Load(fileType, data, dataSize); }
 
     Music(const Music&) = delete;
 
@@ -56,9 +52,7 @@ class Music : public ::Music {
     /**
      * Unload music stream
      */
-    ~Music() {
-        Unload();
-    }
+    ~Music() { Unload(); }
 
     GETTER(::AudioStream, Stream, stream)
     GETTER(unsigned int, FrameCount, frameCount)
@@ -93,9 +87,7 @@ class Music : public ::Music {
     /**
      * Unload music stream
      */
-    void Unload() {
-        ::UnloadMusicStream(*this);
-    }
+    void Unload() { ::UnloadMusicStream(*this); }
 
     /**
      * Start music playing
@@ -148,9 +140,7 @@ class Music : public ::Music {
     /**
      * Check if music is playing
      */
-    bool IsPlaying() const {
-        return ::IsMusicStreamPlaying(*this);
-    }
+    bool IsPlaying() const { return ::IsMusicStreamPlaying(*this); }
 
     /**
      * Set volume for music
@@ -179,16 +169,12 @@ class Music : public ::Music {
     /**
      * Get music time length (in seconds)
      */
-    float GetTimeLength() const {
-        return ::GetMusicTimeLength(*this);
-    }
+    float GetTimeLength() const { return ::GetMusicTimeLength(*this); }
 
     /**
      * Get current music time played (in seconds)
      */
-    float GetTimePlayed() const {
-        return ::GetMusicTimePlayed(*this);
-    }
+    float GetTimePlayed() const { return ::GetMusicTimePlayed(*this); }
 
     /**
      * Load music stream from file
@@ -219,11 +205,8 @@ class Music : public ::Music {
      *
      * @return True or false depending on whether the Music has been loaded.
      */
-    bool IsReady() const {
-        return ::IsMusicReady(*this);
-    }
-
- protected:
+    bool IsReady() const { return ::IsMusicReady(*this); }
+protected:
     void set(const ::Music& music) {
         stream = music.stream;
         frameCount = music.frameCount;
@@ -232,8 +215,8 @@ class Music : public ::Music {
         ctxData = music.ctxData;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RMusic = raylib::Music;
 
-#endif  // RAYLIB_CPP_INCLUDE_MUSIC_HPP_
+#endif // RAYLIB_CPP_INCLUDE_MUSIC_HPP_

--- a/include/Ray.hpp
+++ b/include/Ray.hpp
@@ -1,28 +1,24 @@
 #ifndef RAYLIB_CPP_INCLUDE_RAY_HPP_
 #define RAYLIB_CPP_INCLUDE_RAY_HPP_
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RayCollision.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Ray type (useful for raycast)
  */
 class Ray : public ::Ray {
- public:
-    Ray(const ::Ray& ray) {
-        set(ray);
-    }
+public:
+    Ray(const ::Ray& ray) { set(ray); }
 
-    Ray(::Vector3 position = {0.0f, 0.0f, 0.0f}, ::Vector3 direction = {0.0f, 0.0f, 0.0f}) :
-            ::Ray{position, direction} {
+    Ray(::Vector3 position = {0.0f, 0.0f, 0.0f}, ::Vector3 direction = {0.0f, 0.0f, 0.0f})
+        : ::Ray{position, direction} {
         // Nothing.
     }
 
-    Ray(::Vector2 mousePosition, const ::Camera& camera) {
-        set(::GetMouseRay(mousePosition, camera));
-    }
+    Ray(::Vector2 mousePosition, const ::Camera& camera) { set(::GetMouseRay(mousePosition, camera)); }
 
     Ray& operator=(const ::Ray& ray) {
         set(ray);
@@ -35,9 +31,7 @@ class Ray : public ::Ray {
     /**
      * Draw a ray line
      */
-    void Draw(::Color color) const {
-        DrawRay(*this, color);
-    }
+    void Draw(::Color color) const { DrawRay(*this, color); }
 
     /**
      * Get collision information between ray and sphere
@@ -49,9 +43,7 @@ class Ray : public ::Ray {
     /**
      * Detect collision between ray and box
      */
-    RayCollision GetCollision(const ::BoundingBox& box) const {
-        return ::GetRayCollisionBox(*this, box);
-    }
+    RayCollision GetCollision(const ::BoundingBox& box) const { return ::GetRayCollisionBox(*this, box); }
 
     /**
      * Get collision information between ray and mesh
@@ -84,18 +76,15 @@ class Ray : public ::Ray {
     /**
      * Get a ray trace from mouse position
      */
-    static Ray GetMouse(const ::Camera& camera) {
-        return ::GetMouseRay(::GetMousePosition(), camera);
-    }
-
- protected:
+    static Ray GetMouse(const ::Camera& camera) { return ::GetMouseRay(::GetMousePosition(), camera); }
+protected:
     void set(const ::Ray& ray) {
         position = ray.position;
         direction = ray.direction;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RRay = raylib::Ray;
 
-#endif  // RAYLIB_CPP_INCLUDE_RAY_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RAY_HPP_

--- a/include/RayCollision.hpp
+++ b/include/RayCollision.hpp
@@ -1,30 +1,26 @@
 #ifndef RAYLIB_CPP_INCLUDE_RAYCOLLISION_HPP_
 #define RAYLIB_CPP_INCLUDE_RAYCOLLISION_HPP_
 
-#include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Raycast hit information
  */
 class RayCollision : public ::RayCollision {
- public:
-    RayCollision(const ::RayCollision& ray) {
-        set(ray);
-    }
+public:
+    RayCollision(const ::RayCollision& ray) { set(ray); }
 
-    RayCollision(bool hit, float distance,
-        ::Vector3 point, ::Vector3 normal) : ::RayCollision{hit, distance, point, normal} {
+    RayCollision(bool hit, float distance, ::Vector3 point, ::Vector3 normal)
+        : ::RayCollision{hit, distance, point, normal} {
         // Nothing.
     }
 
     /**
      * Get collision info between ray and bounding box
      */
-    RayCollision(const ::Ray& ray, const ::BoundingBox& box) {
-        set(::GetRayCollisionBox(ray, box));
-    }
+    RayCollision(const ::Ray& ray, const ::BoundingBox& box) { set(::GetRayCollisionBox(ray, box)); }
 
     /**
      * Get collision info between ray and mesh
@@ -63,8 +59,7 @@ class RayCollision : public ::RayCollision {
     GETTERSETTER(float, Distance, distance)
     GETTERSETTER(::Vector3, Position, point)
     GETTERSETTER(::Vector3, Normal, normal)
-
- protected:
+protected:
     void set(const ::RayCollision& ray) {
         hit = ray.hit;
         distance = ray.distance;
@@ -72,8 +67,8 @@ class RayCollision : public ::RayCollision {
         normal = ray.normal;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RRayCollision = raylib::RayCollision;
 
-#endif  // RAYLIB_CPP_INCLUDE_RAYCOLLISION_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RAYCOLLISION_HPP_

--- a/include/RaylibException.hpp
+++ b/include/RaylibException.hpp
@@ -11,7 +11,7 @@ namespace raylib {
  * Exception used for most raylib-related exceptions.
  */
 class RaylibException : public std::runtime_error {
- public:
+public:
     /**
      * Construct a runtime exception with the given message.
      *
@@ -26,13 +26,11 @@ class RaylibException : public std::runtime_error {
      *
      * @param logLevel The output status to use when outputing.
      */
-    void TraceLog(int logLevel = LOG_ERROR) {
-        ::TraceLog(logLevel, std::runtime_error::what());
-    }
+    void TraceLog(int logLevel = LOG_ERROR) { ::TraceLog(logLevel, std::runtime_error::what()); }
 };
 
-}  // namespace raylib
+} // namespace raylib
 
 using RRaylibException = raylib::RaylibException;
 
-#endif  // RAYLIB_CPP_INCLUDE_RAYLIBEXCEPTION_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RAYLIBEXCEPTION_HPP_

--- a/include/Rectangle.hpp
+++ b/include/Rectangle.hpp
@@ -1,16 +1,16 @@
 #ifndef RAYLIB_CPP_INCLUDE_RECTANGLE_HPP_
 #define RAYLIB_CPP_INCLUDE_RECTANGLE_HPP_
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./Vector2.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Rectangle type
  */
 class Rectangle : public ::Rectangle {
- public:
+public:
     Rectangle(const ::Rectangle& rect) : ::Rectangle{rect.x, rect.y, rect.width, rect.height} {}
 
     Rectangle(float x, float y, float width, float height) : ::Rectangle{x, y, width, height} {}
@@ -19,8 +19,7 @@ class Rectangle : public ::Rectangle {
     Rectangle(float x) : ::Rectangle{x, 0, 0, 0} {}
     Rectangle() : ::Rectangle{0, 0, 0, 0} {}
 
-    Rectangle(::Vector2 position, ::Vector2 size)
-            : ::Rectangle{position.x, position.y, size.x, size.y} {}
+    Rectangle(::Vector2 position, ::Vector2 size) : ::Rectangle{position.x, position.y, size.x, size.y} {}
     Rectangle(::Vector2 size) : ::Rectangle{0, 0, size.x, size.y} {}
     Rectangle(::Vector4 rect) : ::Rectangle{rect.x, rect.y, rect.z, rect.w} {}
 
@@ -34,33 +33,37 @@ class Rectangle : public ::Rectangle {
         return *this;
     }
 
-    ::Vector4 ToVector4() {
-        return {x, y, width, height};
-    }
+    ::Vector4 ToVector4() { return {x, y, width, height}; }
 
-    operator ::Vector4() const {
-        return {x, y, width, height};
-    }
+    operator ::Vector4() const { return {x, y, width, height}; }
 
     /**
      * Draw a color-filled rectangle
      */
-    void Draw(::Color color) const {
-        ::DrawRectangleRec(*this, color);
-    }
+    void Draw(::Color color) const { ::DrawRectangleRec(*this, color); }
 
     void Draw(::Vector2 origin, float rotation, ::Color color) const {
         ::DrawRectanglePro(*this, origin, rotation, color);
     }
 
     void DrawGradientV(::Color color1, ::Color color2) const {
-        ::DrawRectangleGradientV(static_cast<int>(x), static_cast<int>(y), static_cast<int>(width),
-            static_cast<int>(height), color1, color2);
+        ::DrawRectangleGradientV(
+            static_cast<int>(x),
+            static_cast<int>(y),
+            static_cast<int>(width),
+            static_cast<int>(height),
+            color1,
+            color2);
     }
 
     void DrawGradientH(::Color color1, ::Color color2) const {
-        ::DrawRectangleGradientH(static_cast<int>(x), static_cast<int>(y), static_cast<int>(width),
-            static_cast<int>(height), color1, color2);
+        ::DrawRectangleGradientH(
+            static_cast<int>(x),
+            static_cast<int>(y),
+            static_cast<int>(width),
+            static_cast<int>(height),
+            color1,
+            color2);
     }
 
     void DrawGradient(::Color col1, ::Color col2, ::Color col3, ::Color col4) const {
@@ -68,55 +71,50 @@ class Rectangle : public ::Rectangle {
     }
 
     void DrawLines(::Color color) const {
-        ::DrawRectangleLines(static_cast<int>(x), static_cast<int>(y), static_cast<int>(width),
-            static_cast<int>(height), color);
+        ::DrawRectangleLines(
+            static_cast<int>(x),
+            static_cast<int>(y),
+            static_cast<int>(width),
+            static_cast<int>(height),
+            color);
     }
 
-    void DrawLines(::Color color, float lineThick) const {
-        ::DrawRectangleLinesEx(*this, lineThick, color);
-    }
+    void DrawLines(::Color color, float lineThick) const { ::DrawRectangleLinesEx(*this, lineThick, color); }
 
     void DrawRounded(float roundness, int segments, ::Color color) const {
         ::DrawRectangleRounded(*this, roundness, segments, color);
     }
 
     void DrawRoundedLines(float roundness, int segments, ::Color color) const {
-        #if RAYLIB_VERSION_MAJOR == 5 && RAYLIB_VERSION_MINOR == 0
-            ::DrawRectangleRoundedLines(*this, roundness, segments, 1.0f, color);
-        #else
-            ::DrawRectangleRoundedLines(*this, roundness, segments, color);
-        #endif
+#if RAYLIB_VERSION_MAJOR == 5 && RAYLIB_VERSION_MINOR == 0
+        ::DrawRectangleRoundedLines(*this, roundness, segments, 1.0f, color);
+#else
+        ::DrawRectangleRoundedLines(*this, roundness, segments, color);
+#endif
     }
 
-    void DrawRoundedLines(float roundness, int segments,
-            float lineThick, ::Color color) const {
-        #if RAYLIB_VERSION_MAJOR == 5 && RAYLIB_VERSION_MINOR == 0
-            ::DrawRectangleRoundedLines(*this, roundness, segments, lineThick, color);
-        #else
-            DrawRectangleRoundedLinesEx(*this, roundness, segments, lineThick, color);
-        #endif
+    void DrawRoundedLines(float roundness, int segments, float lineThick, ::Color color) const {
+#if RAYLIB_VERSION_MAJOR == 5 && RAYLIB_VERSION_MINOR == 0
+        ::DrawRectangleRoundedLines(*this, roundness, segments, lineThick, color);
+#else
+        DrawRectangleRoundedLinesEx(*this, roundness, segments, lineThick, color);
+#endif
     }
 
     /**
      * Check collision between two rectangles
      */
-    bool CheckCollision(::Rectangle rec2) const {
-        return ::CheckCollisionRecs(*this, rec2);
-    }
+    bool CheckCollision(::Rectangle rec2) const { return ::CheckCollisionRecs(*this, rec2); }
 
     /**
      * Get collision rectangle for two rectangles collision
      */
-    ::Rectangle GetCollision(::Rectangle rec2) const {
-        return ::GetCollisionRec(*this, rec2);
-    }
+    ::Rectangle GetCollision(::Rectangle rec2) const { return ::GetCollisionRec(*this, rec2); }
 
     /**
      * Check if point is inside rectangle
      */
-    bool CheckCollision(::Vector2 point) const {
-        return ::CheckCollisionPointRec(point, *this);
-    }
+    bool CheckCollision(::Vector2 point) const { return ::CheckCollisionPointRec(point, *this); }
 
     /**
      * Check collision between circle and rectangle
@@ -125,9 +123,7 @@ class Rectangle : public ::Rectangle {
         return ::CheckCollisionCircleRec(center, radius, *this);
     }
 
-    Vector2 GetSize() const {
-        return {width, height};
-    }
+    Vector2 GetSize() const { return {width, height}; }
 
     Rectangle& SetSize(float newWidth, float newHeight) {
         width = newWidth;
@@ -135,18 +131,14 @@ class Rectangle : public ::Rectangle {
         return *this;
     }
 
-    Rectangle& SetSize(const ::Vector2& size) {
-        return SetSize(size.x, size.y);
-    }
+    Rectangle& SetSize(const ::Vector2& size) { return SetSize(size.x, size.y); }
 
     Rectangle& SetShapesTexture(const ::Texture2D& texture) {
         ::SetShapesTexture(texture, *this);
         return *this;
     }
 
-    Vector2 GetPosition() const {
-        return {x, y};
-    }
+    Vector2 GetPosition() const { return {x, y}; }
 
     Rectangle& SetPosition(float newX, float newY) {
         x = newX;
@@ -154,11 +146,8 @@ class Rectangle : public ::Rectangle {
         return *this;
     }
 
-    Rectangle& SetPosition(const ::Vector2& position) {
-        return SetPosition(position.x, position.y);
-    }
-
- protected:
+    Rectangle& SetPosition(const ::Vector2& position) { return SetPosition(position.x, position.y); }
+protected:
     void set(const ::Rectangle& rect) {
         x = rect.x;
         y = rect.y;
@@ -166,8 +155,8 @@ class Rectangle : public ::Rectangle {
         height = rect.height;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RRectangle = raylib::Rectangle;
 
-#endif  // RAYLIB_CPP_INCLUDE_RECTANGLE_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RECTANGLE_HPP_

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -1,37 +1,31 @@
 #ifndef RAYLIB_CPP_INCLUDE_RENDERTEXTURE_HPP_
 #define RAYLIB_CPP_INCLUDE_RENDERTEXTURE_HPP_
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
 #include "./TextureUnmanaged.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * RenderTexture type, for texture rendering
  */
 class RenderTexture : public ::RenderTexture {
- public:
+public:
     /**
      * Default constructor to build an empty RenderTexture.
      */
-    RenderTexture() {
-        id = 0;
-    }
+    RenderTexture() { id = 0; }
 
-    RenderTexture(const ::RenderTexture& renderTexture) {
-        set(renderTexture);
-    }
+    RenderTexture(const ::RenderTexture& renderTexture) { set(renderTexture); }
 
-    RenderTexture(unsigned int id, const ::Texture& texture, const ::Texture& depth) :
-        ::RenderTexture{id, texture, depth} {}
+    RenderTexture(unsigned int id, const ::Texture& texture, const ::Texture& depth)
+        : ::RenderTexture{id, texture, depth} {}
 
     /**
      * Load texture for rendering (framebuffer)
      */
-    RenderTexture(int width, int height) {
-        set(::LoadRenderTexture(width, height));
-    }
+    RenderTexture(int width, int height) { set(::LoadRenderTexture(width, height)); }
 
     RenderTexture(const RenderTexture&) = delete;
 
@@ -48,24 +42,16 @@ class RenderTexture : public ::RenderTexture {
     /**
      * Get the color buffer attachment texture.
      */
-    TextureUnmanaged GetTexture() {
-        return texture;
-    }
+    TextureUnmanaged GetTexture() { return texture; }
 
-    void SetTexture(const ::Texture& newTexture) {
-        texture = newTexture;
-    }
+    void SetTexture(const ::Texture& newTexture) { texture = newTexture; }
 
     /**
      * Depth buffer attachment texture
      */
-    TextureUnmanaged GetDepth() {
-        return depth;
-    }
+    TextureUnmanaged GetDepth() { return depth; }
 
-    void SetDepth(const ::Texture& newDepth) {
-        depth = newDepth;
-    }
+    void SetDepth(const ::Texture& newDepth) { depth = newDepth; }
 
     RenderTexture& operator=(const ::RenderTexture& texture) {
         set(texture);
@@ -89,13 +75,9 @@ class RenderTexture : public ::RenderTexture {
         return *this;
     }
 
-    ~RenderTexture() {
-        Unload();
-    }
+    ~RenderTexture() { Unload(); }
 
-    void Unload() {
-        UnloadRenderTexture(*this);
-    }
+    void Unload() { UnloadRenderTexture(*this); }
 
     /**
      * Initializes render texture for drawing
@@ -116,18 +98,13 @@ class RenderTexture : public ::RenderTexture {
     /**
      * Load texture for rendering (framebuffer)
      */
-    static RenderTexture Load(int width, int height) {
-        return ::LoadRenderTexture(width, height);
-    }
+    static RenderTexture Load(int width, int height) { return ::LoadRenderTexture(width, height); }
 
     /**
      * Retrieves whether or not the render texture is ready.
      */
-    bool IsReady() const {
-        return ::IsRenderTextureReady(*this);
-    }
-
- protected:
+    bool IsReady() const { return ::IsRenderTextureReady(*this); }
+protected:
     void set(const ::RenderTexture& renderTexture) {
         id = renderTexture.id;
         texture = renderTexture.texture;
@@ -137,9 +114,9 @@ class RenderTexture : public ::RenderTexture {
 
 using RenderTexture2D = RenderTexture;
 
-}  // namespace raylib
+} // namespace raylib
 
 using RRenderTexture = raylib::RenderTexture;
 using RRenderTexture2D = raylib::RenderTexture2D;
 
-#endif  // RAYLIB_CPP_INCLUDE_RENDERTEXTURE_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RENDERTEXTURE_HPP_

--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -3,17 +3,17 @@
 
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
-#include "Texture.hpp"
 #include "ShaderUnmanaged.hpp"
+#include "Texture.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Shader type (generic)
  */
 class Shader : public ShaderUnmanaged {
- public:
+public:
     using ShaderUnmanaged::ShaderUnmanaged;
 
     Shader(const Shader&) = delete;
@@ -44,9 +44,7 @@ class Shader : public ShaderUnmanaged {
     /**
      * Unload shader from GPU memory (VRAM)
      */
-    ~Shader() {
-        Unload();
-    }
+    ~Shader() { Unload(); }
 
     /**
      * Unload shader from GPU memory (VRAM)
@@ -57,8 +55,8 @@ class Shader : public ShaderUnmanaged {
         }
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RShader = raylib::Shader;
 
-#endif  // RAYLIB_CPP_INCLUDE_SHADER_HPP_
+#endif // RAYLIB_CPP_INCLUDE_SHADER_HPP_

--- a/include/ShaderUnmanaged.hpp
+++ b/include/ShaderUnmanaged.hpp
@@ -4,9 +4,9 @@
 #include <rlgl.h>
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "Texture.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 
@@ -14,21 +14,17 @@ namespace raylib {
  * Shader type (generic), not managed by C++ RAII.
  */
 class ShaderUnmanaged : public ::Shader {
- public:
+public:
     ShaderUnmanaged() : ::Shader{rlGetShaderIdDefault(), rlGetShaderLocsDefault()} {}
 
-    ShaderUnmanaged(const ::Shader& shader) {
-        set(shader);
-    }
+    ShaderUnmanaged(const ::Shader& shader) { set(shader); }
 
     ShaderUnmanaged(unsigned int id, int* locs = nullptr) : ::Shader{id, locs} {}
 
     ShaderUnmanaged(const std::string& vsFileName, const std::string& fsFileName) {
         set(::LoadShader(vsFileName.c_str(), fsFileName.c_str()));
     }
-    ShaderUnmanaged(const char* vsFileName, const char* fsFileName) {
-        set(::LoadShader(vsFileName, fsFileName));
-    }
+    ShaderUnmanaged(const char* vsFileName, const char* fsFileName) { set(::LoadShader(vsFileName, fsFileName)); }
 
     /**
      * Load shader from files and bind default locations.
@@ -83,9 +79,7 @@ class ShaderUnmanaged : public ::Shader {
      *
      * @see GetShaderLocation()
      */
-    int GetLocation(const std::string& uniformName) const {
-        return ::GetShaderLocation(*this, uniformName.c_str());
-    }
+    int GetLocation(const std::string& uniformName) const { return ::GetShaderLocation(*this, uniformName.c_str()); }
 
     /**
      * Get shader attribute location
@@ -139,18 +133,15 @@ class ShaderUnmanaged : public ::Shader {
     /**
      * Retrieves whether or not the shader is ready.
      */
-    bool IsReady() const {
-        return id != 0 && locs != nullptr;
-    }
-
- protected:
+    bool IsReady() const { return id != 0 && locs != nullptr; }
+protected:
     void set(const ::Shader& shader) {
         id = shader.id;
         locs = shader.locs;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RShaderUnmanaged = raylib::ShaderUnmanaged;
 
-#endif  // RAYLIB_CPP_INCLUDE_UNMANAGEDSHADER_HPP_
+#endif // RAYLIB_CPP_INCLUDE_UNMANAGEDSHADER_HPP_

--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -3,9 +3,9 @@
 
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
@@ -17,12 +17,12 @@ namespace raylib {
  * @endcode
  */
 class Sound : public ::Sound {
- public:
+public:
     Sound(const Sound&) = delete;
     Sound& operator=(const Sound&) = delete;
 
     Sound() {
-        stream = { nullptr, nullptr, 0, 0, 0 };
+        stream = {nullptr, nullptr, 0, 0, 0};
         frameCount = 0;
     }
 
@@ -33,7 +33,7 @@ class Sound : public ::Sound {
     Sound(Sound&& other) {
         set(other);
 
-        other.stream = { nullptr, nullptr, 0, 0, 0 };
+        other.stream = {nullptr, nullptr, 0, 0, 0};
         other.frameCount = 0;
     }
 
@@ -42,22 +42,16 @@ class Sound : public ::Sound {
      *
      * @throws raylib::RaylibException Throws if the Sound failed to load.
      */
-    Sound(const std::string& fileName) {
-        Load(fileName);
-    }
+    Sound(const std::string& fileName) { Load(fileName); }
 
     /**
      * Loads a sound from the given Wave.
      *
      * @throws raylib::RaylibException Throws if the Sound failed to load.
      */
-    Sound(const ::Wave& wave) {
-        Load(wave);
-    }
+    Sound(const ::Wave& wave) { Load(wave); }
 
-    ~Sound() {
-        Unload();
-    }
+    ~Sound() { Unload(); }
 
     GETTER(unsigned int, FrameCount, frameCount)
     GETTER(::AudioStream, Stream, stream)
@@ -70,7 +64,7 @@ class Sound : public ::Sound {
         Unload();
         set(other);
         other.frameCount = 0;
-        other.stream = { nullptr, nullptr, 0, 0, 0 };
+        other.stream = {nullptr, nullptr, 0, 0, 0};
 
         return *this;
     }
@@ -78,7 +72,7 @@ class Sound : public ::Sound {
     /**
      * Update sound buffer with new data
      */
-    Sound& Update(const void *data, int samplesCount) {
+    Sound& Update(const void* data, int samplesCount) {
         ::UpdateSound(*this, data, samplesCount);
         return *this;
     }
@@ -86,7 +80,7 @@ class Sound : public ::Sound {
     /**
      * Update sound buffer with new data, assuming it's the same sample count.
      */
-    Sound& Update(const void *data) {
+    Sound& Update(const void* data) {
         ::UpdateSound(*this, data, static_cast<int>(frameCount));
         return *this;
     }
@@ -137,9 +131,7 @@ class Sound : public ::Sound {
     /**
      * Check if a sound is currently playing
      */
-    bool IsPlaying() const {
-        return ::IsSoundPlaying(*this);
-    }
+    bool IsPlaying() const { return ::IsSoundPlaying(*this); }
 
     /**
      * Set volume for a sound (1.0 is max level)
@@ -194,18 +186,15 @@ class Sound : public ::Sound {
      *
      * @return True or false depending on whether the Sound buffer is loaded.
      */
-    bool IsReady() const {
-        return ::IsSoundReady(*this);
-    }
-
- protected:
+    bool IsReady() const { return ::IsSoundReady(*this); }
+protected:
     void set(const ::Sound& sound) {
         frameCount = sound.frameCount;
         stream = sound.stream;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RSound = raylib::Sound;
 
-#endif  // RAYLIB_CPP_INCLUDE_SOUND_HPP_
+#endif // RAYLIB_CPP_INCLUDE_SOUND_HPP_

--- a/include/Text.hpp
+++ b/include/Text.hpp
@@ -3,16 +3,16 @@
 
 #include <string>
 
-#include "./raylib.hpp"
 #include "./RaylibException.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Text Functions.
  */
 class Text {
- public:
+public:
     /**
      * The internal text.
      */
@@ -48,16 +48,16 @@ class Text {
      * @param spacing The spacing of the text.
      */
     Text(
-            const std::string& text = "",
-            float fontSize = 10,
-            const ::Color& color = WHITE,
-            const ::Font& font = ::GetFontDefault(),
-            float spacing = 0) :
-            text(text),
-            fontSize(fontSize),
-            color(color),
-            font(font),
-            spacing(spacing) {
+        const std::string& text = "",
+        float fontSize = 10,
+        const ::Color& color = WHITE,
+        const ::Font& font = ::GetFontDefault(),
+        float spacing = 0)
+        : text(text)
+        , fontSize(fontSize)
+        , color(color)
+        , font(font)
+        , spacing(spacing) {
         // Nothing.
     }
 
@@ -71,16 +71,16 @@ class Text {
      * @param color The color of the font.
      */
     Text(
-            const ::Font& font,
-            const std::string& text = "",
-            float fontSize = 10,
-            float spacing = 0,
-            const ::Color& color = WHITE) :
-            text(text),
-            fontSize(fontSize),
-            color(color),
-            font(font),
-            spacing(spacing) {
+        const ::Font& font,
+        const std::string& text = "",
+        float fontSize = 10,
+        float spacing = 0,
+        const ::Color& color = WHITE)
+        : text(text)
+        , fontSize(fontSize)
+        , color(color)
+        , font(font)
+        , spacing(spacing) {
         // Nothing.
     }
 
@@ -93,17 +93,16 @@ class Text {
     /**
      * Draw text with values in class.
      */
-    void Draw(const ::Vector2& position) const {
-        ::DrawTextEx(font, text.c_str(), position, fontSize, spacing, color);
-    }
+    void Draw(const ::Vector2& position) const { ::DrawTextEx(font, text.c_str(), position, fontSize, spacing, color); }
 
     /**
      * Draw text with values in class.
      */
     void Draw(int posX, int posY) const {
-        ::DrawTextEx(font,
+        ::DrawTextEx(
+            font,
             text.c_str(),
-            { static_cast<float>(posX), static_cast<float>(posY) },
+            {static_cast<float>(posX), static_cast<float>(posY)},
             fontSize,
             spacing,
             color);
@@ -121,16 +120,12 @@ class Text {
     /**
      * Measure string width for default font
      */
-    int Measure() const {
-        return ::MeasureText(text.c_str(), static_cast<int>(fontSize));
-    }
+    int Measure() const { return ::MeasureText(text.c_str(), static_cast<int>(fontSize)); }
 
     /**
      * Measure string size for Font
      */
-    Vector2 MeasureEx() const {
-        return ::MeasureTextEx(font, text.c_str(), fontSize, spacing);
-    }
+    Vector2 MeasureEx() const { return ::MeasureTextEx(font, text.c_str(), fontSize, spacing); }
 
     Text& operator=(const Text& other) {
         if (this == &other) {
@@ -151,12 +146,8 @@ class Text {
      *
      * @see ::DrawText
      */
-    static void Draw(
-            const std::string& text,
-            const int posX,
-            const int posY,
-            const int fontSize,
-            const ::Color& color) {
+    static void
+    Draw(const std::string& text, const int posX, const int posY, const int fontSize, const ::Color& color) {
         ::DrawText(text.c_str(), posX, posY, fontSize, color);
     }
 
@@ -165,11 +156,7 @@ class Text {
      *
      * @see ::DrawText
      */
-    static void Draw(
-            const std::string& text,
-            const ::Vector2& pos,
-            const int fontSize,
-            const ::Color& color) {
+    static void Draw(const std::string& text, const ::Vector2& pos, const int fontSize, const ::Color& color) {
         ::DrawText(text.c_str(), static_cast<int>(pos.x), static_cast<int>(pos.y), fontSize, color);
     }
 
@@ -179,12 +166,12 @@ class Text {
      * @see ::DrawTextEx
      */
     static void Draw(
-            const ::Font& font,
-            const std::string& text,
-            const ::Vector2& position,
-            const float fontSize,
-            const float spacing,
-            const ::Color& color) {
+        const ::Font& font,
+        const std::string& text,
+        const ::Vector2& position,
+        const float fontSize,
+        const float spacing,
+        const ::Color& color) {
         ::DrawTextEx(font, text.c_str(), position, fontSize, spacing, color);
     }
 
@@ -194,19 +181,19 @@ class Text {
      * @see ::DrawTextPro
      */
     static void Draw(
-            const ::Font& font,
-            const std::string& text,
-            const ::Vector2& position,
-            const ::Vector2& origin,
-            const float rotation,
-            const float fontSize,
-            const float spacing,
-            const ::Color& color) {
+        const ::Font& font,
+        const std::string& text,
+        const ::Vector2& position,
+        const ::Vector2& origin,
+        const float rotation,
+        const float fontSize,
+        const float spacing,
+        const ::Color& color) {
         ::DrawTextPro(font, text.c_str(), position, origin, rotation, fontSize, spacing, color);
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RText = raylib::Text;
 
-#endif  // RAYLIB_CPP_INCLUDE_TEXT_HPP_
+#endif // RAYLIB_CPP_INCLUDE_TEXT_HPP_

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -12,7 +12,7 @@ namespace raylib {
  * @see raylib::TextureUnmanaged
  */
 class Texture : public TextureUnmanaged {
- public:
+public:
     using TextureUnmanaged::TextureUnmanaged;
 
     /**
@@ -41,9 +41,7 @@ class Texture : public TextureUnmanaged {
     /**
      * On destruction, unload the Texture.
      */
-    ~Texture() {
-        Unload();
-    }
+    ~Texture() { Unload(); }
 
     /**
      * Move assignment.
@@ -70,10 +68,10 @@ class Texture : public TextureUnmanaged {
 using Texture2D = Texture;
 using TextureCubemap = Texture;
 
-}  // namespace raylib
+} // namespace raylib
 
 using RTexture = raylib::Texture;
 using RTexture2D = raylib::Texture2D;
 using RTextureCubemap = raylib::TextureCubemap;
 
-#endif  // RAYLIB_CPP_INCLUDE_TEXTURE_HPP_
+#endif // RAYLIB_CPP_INCLUDE_TEXTURE_HPP_

--- a/include/TextureUnmanaged.hpp
+++ b/include/TextureUnmanaged.hpp
@@ -3,12 +3,12 @@
 
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
-#include "./Vector2.hpp"
+#include "./Image.hpp"
 #include "./Material.hpp"
 #include "./RaylibException.hpp"
-#include "./Image.hpp"
+#include "./Vector2.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
@@ -19,7 +19,7 @@ namespace raylib {
  * @see raylib::Texture
  */
 class TextureUnmanaged : public ::Texture {
- public:
+public:
     /**
      * Default texture constructor.
      */
@@ -30,19 +30,21 @@ class TextureUnmanaged : public ::Texture {
     /**
      * Move/Create a texture structure manually.
      */
-    TextureUnmanaged(unsigned int id,
-            int width, int height,
-            int mipmaps = 1,
-            int format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8)
-            : ::Texture{id, width, height, mipmaps, format} {
+    TextureUnmanaged(
+        unsigned int id,
+        int width,
+        int height,
+        int mipmaps = 1,
+        int format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8)
+        : ::Texture{id, width, height, mipmaps, format} {
         // Nothing.
     }
 
     /**
      * Creates a texture object based on the given Texture struct data.
      */
-    TextureUnmanaged(const ::Texture& texture) :
-            ::Texture{texture.id, texture.width, texture.height, texture.mipmaps, texture.format} {
+    TextureUnmanaged(const ::Texture& texture)
+        : ::Texture{texture.id, texture.width, texture.height, texture.mipmaps, texture.format} {
         // Nothing.
     }
 
@@ -51,9 +53,7 @@ class TextureUnmanaged : public ::Texture {
      *
      * @throws raylib::RaylibException Throws if failed to create the texture from the given image.
      */
-    TextureUnmanaged(const ::Image& image) {
-        Load(image);
-    }
+    TextureUnmanaged(const ::Image& image) { Load(image); }
 
     /**
      * Load cubemap from image, multiple image cubemap layouts supported.
@@ -62,21 +62,16 @@ class TextureUnmanaged : public ::Texture {
      *
      * @see LoadTextureCubemap()
      */
-    TextureUnmanaged(const ::Image& image, int layout) {
-        Load(image, layout);
-    }
+    TextureUnmanaged(const ::Image& image, int layout) { Load(image, layout); }
 
     /**
      * Load texture from file into GPU memory (VRAM)
      *
      * @throws raylib::RaylibException Throws if failed to create the texture from the given file.
      */
-    TextureUnmanaged(const std::string& fileName) {
-        Load(fileName);
-    }
+    TextureUnmanaged(const std::string& fileName) { Load(fileName); }
 
-    TextureUnmanaged(::Texture&& other) :
-            ::Texture{other.id, other.width, other.height, other.mipmaps, other.format} {
+    TextureUnmanaged(::Texture&& other) : ::Texture{other.id, other.width, other.height, other.mipmaps, other.format} {
         // Nothing.
     }
 
@@ -94,9 +89,7 @@ class TextureUnmanaged : public ::Texture {
     /**
      * Retrieve the width and height of the texture.
      */
-    ::Vector2 GetSize() const {
-        return {static_cast<float>(width), static_cast<float>(height)};
-    }
+    ::Vector2 GetSize() const { return {static_cast<float>(width), static_cast<float>(height)}; }
 
     /**
      * Load texture from image data
@@ -142,7 +135,7 @@ class TextureUnmanaged : public ::Texture {
     /**
      * Update GPU texture with new data
      */
-    TextureUnmanaged& Update(const void *pixels) {
+    TextureUnmanaged& Update(const void* pixels) {
         ::UpdateTexture(*this, pixels);
         return *this;
     }
@@ -150,7 +143,7 @@ class TextureUnmanaged : public ::Texture {
     /**
      * Update GPU texture rectangle with new data
      */
-    TextureUnmanaged& Update(::Rectangle rec, const void *pixels) {
+    TextureUnmanaged& Update(::Rectangle rec, const void* pixels) {
         UpdateTextureRec(*this, rec, pixels);
         return *this;
     }
@@ -158,16 +151,12 @@ class TextureUnmanaged : public ::Texture {
     /**
      * Get pixel data from GPU texture and return an Image
      */
-    ::Image GetData() const {
-        return ::LoadImageFromTexture(*this);
-    }
+    ::Image GetData() const { return ::LoadImageFromTexture(*this); }
 
     /**
      * Get pixel data from GPU texture and return an Image
      */
-    operator Image() {
-        return GetData();
-    }
+    operator Image() { return GetData(); }
 
     /**
      * Generate GPU mipmaps for a texture
@@ -207,17 +196,14 @@ class TextureUnmanaged : public ::Texture {
      *
      * @see ::DrawTextureV()
      */
-    void Draw(::Vector2 position, ::Color tint = {255, 255, 255, 255}) const {
-        ::DrawTextureV(*this, position, tint);
-    }
+    void Draw(::Vector2 position, ::Color tint = {255, 255, 255, 255}) const { ::DrawTextureV(*this, position, tint); }
 
     /**
      * Draw a Texture2D with extended parameters
      *
      * @see ::DrawTextureEx()
      */
-    void Draw(::Vector2 position, float rotation, float scale = 1.0f,
-            ::Color tint = {255, 255, 255, 255}) const {
+    void Draw(::Vector2 position, float rotation, float scale = 1.0f, ::Color tint = {255, 255, 255, 255}) const {
         ::DrawTextureEx(*this, position, rotation, scale, tint);
     }
 
@@ -226,8 +212,7 @@ class TextureUnmanaged : public ::Texture {
      *
      * @see ::DrawTextureRec()
      */
-    void Draw(::Rectangle sourceRec, ::Vector2 position = {0, 0},
-            ::Color tint = {255, 255, 255, 255}) const {
+    void Draw(::Rectangle sourceRec, ::Vector2 position = {0, 0}, ::Color tint = {255, 255, 255, 255}) const {
         ::DrawTextureRec(*this, sourceRec, position, tint);
     }
 
@@ -236,8 +221,12 @@ class TextureUnmanaged : public ::Texture {
      *
      * @see ::DrawTexturePro()
      */
-    void Draw(::Rectangle sourceRec, ::Rectangle destRec, ::Vector2 origin = {0, 0},
-            float rotation = 0, ::Color tint = {255, 255, 255, 255}) const {
+    void Draw(
+        ::Rectangle sourceRec,
+        ::Rectangle destRec,
+        ::Vector2 origin = {0, 0},
+        float rotation = 0,
+        ::Color tint = {255, 255, 255, 255}) const {
         ::DrawTexturePro(*this, sourceRec, destRec, origin, rotation, tint);
     }
 
@@ -246,8 +235,12 @@ class TextureUnmanaged : public ::Texture {
      *
      * @see ::DrawTextureNPatch()
      */
-    void Draw(::NPatchInfo nPatchInfo, ::Rectangle destRec, ::Vector2 origin = {0, 0},
-            float rotation = 0, ::Color tint = {255, 255, 255, 255}) const {
+    void Draw(
+        ::NPatchInfo nPatchInfo,
+        ::Rectangle destRec,
+        ::Vector2 origin = {0, 0},
+        float rotation = 0,
+        ::Color tint = {255, 255, 255, 255}) const {
         ::DrawTextureNPatch(*this, nPatchInfo, destRec, origin, rotation, tint);
     }
 
@@ -256,9 +249,8 @@ class TextureUnmanaged : public ::Texture {
      *
      * @see ::DrawBillboard()
      */
-    void DrawBillboard(const ::Camera& camera,
-            ::Vector3 position, float size,
-            ::Color tint = {255, 255, 255, 255}) const {
+    void
+    DrawBillboard(const ::Camera& camera, ::Vector3 position, float size, ::Color tint = {255, 255, 255, 255}) const {
         ::DrawBillboard(camera, *this, position, size, tint);
     }
 
@@ -267,9 +259,12 @@ class TextureUnmanaged : public ::Texture {
      *
      * @see ::DrawBillboardRec()
      */
-    void DrawBillboard(const ::Camera& camera,
-            ::Rectangle source, ::Vector3 position, ::Vector2 size,
-            ::Color tint = {255, 255, 255, 255}) const {
+    void DrawBillboard(
+        const ::Camera& camera,
+        ::Rectangle source,
+        ::Vector3 position,
+        ::Vector2 size,
+        ::Color tint = {255, 255, 255, 255}) const {
         DrawBillboardRec(camera, *this, source, position, size, tint);
     }
 
@@ -278,17 +273,22 @@ class TextureUnmanaged : public ::Texture {
      *
      * @see ::DrawBillboardPro()
      */
-    void DrawBillboard(const ::Camera& camera,
-            ::Rectangle source, Vector3 position,
-            ::Vector3 up, Vector2 size, Vector2 origin, float rotation = 0.0f,
-            ::Color tint = {255, 255, 255, 255}) const {
+    void DrawBillboard(
+        const ::Camera& camera,
+        ::Rectangle source,
+        Vector3 position,
+        ::Vector3 up,
+        Vector2 size,
+        Vector2 origin,
+        float rotation = 0.0f,
+        ::Color tint = {255, 255, 255, 255}) const {
         DrawBillboardPro(camera, *this, source, position, up, size, origin, rotation, tint);
     }
 
     /**
      * Set texture for a material map type (MAP_DIFFUSE, MAP_SPECULAR...)
      */
-    TextureUnmanaged& SetMaterial(::Material *material, int mapType = MATERIAL_MAP_NORMAL) {
+    TextureUnmanaged& SetMaterial(::Material* material, int mapType = MATERIAL_MAP_NORMAL) {
         ::SetMaterialTexture(material, mapType, *this);
         return *this;
     }
@@ -319,11 +319,8 @@ class TextureUnmanaged : public ::Texture {
      *
      * @return True or false depending on whether the Texture has data.
      */
-    bool IsReady() const {
-        return id != 0;
-    }
-
- protected:
+    bool IsReady() const { return id != 0; }
+protected:
     void set(const ::Texture& texture) {
         id = texture.id;
         width = texture.width;
@@ -337,10 +334,10 @@ class TextureUnmanaged : public ::Texture {
 using Texture2DUnmanaged = TextureUnmanaged;
 using TextureCubemapUnmanaged = TextureUnmanaged;
 
-}  // namespace raylib
+} // namespace raylib
 
 using RTextureUnmanaged = raylib::TextureUnmanaged;
 using RTexture2DUnmanaged = raylib::Texture2DUnmanaged;
 using RTextureCubemapUnmanaged = raylib::TextureCubemapUnmanaged;
 
-#endif  // RAYLIB_CPP_INCLUDE_TEXTUREUNMANAGED_HPP_
+#endif // RAYLIB_CPP_INCLUDE_TEXTUREUNMANAGED_HPP_

--- a/include/Touch.hpp
+++ b/include/Touch.hpp
@@ -8,43 +8,43 @@ namespace raylib {
  * Input-related functions: touch
  */
 namespace Touch {
-    /**
-     * Get touch position X for touch point 0 (relative to screen size)
-     */
-    [[maybe_unused]] RLCPPAPI inline int GetX() {
-        return ::GetTouchX();
-    }
+/**
+ * Get touch position X for touch point 0 (relative to screen size)
+ */
+[[maybe_unused]] RLCPPAPI inline int GetX() {
+    return ::GetTouchX();
+}
 
-    /**
-     * Get touch position Y for touch point 0 (relative to screen size)
-     */
-    [[maybe_unused]] RLCPPAPI inline int GetY() {
-        return ::GetTouchY();
-    }
+/**
+ * Get touch position Y for touch point 0 (relative to screen size)
+ */
+[[maybe_unused]] RLCPPAPI inline int GetY() {
+    return ::GetTouchY();
+}
 
-    /**
-     * Get touch position XY for a touch point index (relative to screen size)
-     */
-    [[maybe_unused]] RLCPPAPI inline Vector2 GetPosition(int index) {
-        return ::GetTouchPosition(index);
-    }
+/**
+ * Get touch position XY for a touch point index (relative to screen size)
+ */
+[[maybe_unused]] RLCPPAPI inline Vector2 GetPosition(int index) {
+    return ::GetTouchPosition(index);
+}
 
-    /**
-     * Get touch point identifier for given index
-     */
-    [[maybe_unused]] RLCPPAPI inline int GetPointId(int index) {
-        return ::GetTouchPointId(index);
-    }
+/**
+ * Get touch point identifier for given index
+ */
+[[maybe_unused]] RLCPPAPI inline int GetPointId(int index) {
+    return ::GetTouchPointId(index);
+}
 
-    /**
-     * Get number of touch points
-     */
-    [[maybe_unused]] RLCPPAPI inline int GetPointCount() {
-        return ::GetTouchPointCount();
-    }
-}  // namespace Touch
-}  // namespace raylib
+/**
+ * Get number of touch points
+ */
+[[maybe_unused]] RLCPPAPI inline int GetPointCount() {
+    return ::GetTouchPointCount();
+}
+} // namespace Touch
+} // namespace raylib
 
 namespace RTouch = raylib::Touch;
 
-#endif  // RAYLIB_CPP_INCLUDE_TOUCH_HPP_
+#endif // RAYLIB_CPP_INCLUDE_TOUCH_HPP_

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -7,16 +7,16 @@
 
 #include <string>
 
+#include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
 #include "./raymath.hpp"
-#include "./raylib-cpp-utils.hpp"
 
 namespace raylib {
 /**
  * Vector2 type
  */
 class Vector2 : public ::Vector2 {
- public:
+public:
     Vector2(const ::Vector2& vec) : ::Vector2{vec.x, vec.y} {}
 
     Vector2(float x, float y) : ::Vector2{x, y} {}
@@ -37,40 +37,27 @@ class Vector2 : public ::Vector2 {
     /**
      * Determine whether or not the vectors are equal.
      */
-    bool operator==(const ::Vector2& other) const {
-        return x == other.x
-            && y == other.y;
-    }
+    bool operator==(const ::Vector2& other) const { return x == other.x && y == other.y; }
 
     /**
      * Determines if the vectors are not equal.
      */
-    bool operator!=(const ::Vector2& other) const {
-        return !(*this == other);
-    }
+    bool operator!=(const ::Vector2& other) const { return !(*this == other); }
 
-    std::string ToString() const {
-        return TextFormat("Vector2(%f, %f)", x, y);
-    }
+    std::string ToString() const { return TextFormat("Vector2(%f, %f)", x, y); }
 
-    operator std::string() const {
-        return ToString();
-    }
+    operator std::string() const { return ToString(); }
 
 #ifndef RAYLIB_CPP_NO_MATH
     /**
      * Add two vectors (v1 + v2)
      */
-    Vector2 Add(const ::Vector2& vector2) const {
-        return Vector2Add(*this, vector2);
-    }
+    Vector2 Add(const ::Vector2& vector2) const { return Vector2Add(*this, vector2); }
 
     /**
      * Add two vectors (v1 + v2)
      */
-    Vector2 operator+(const ::Vector2& vector2) const {
-        return Vector2Add(*this, vector2);
-    }
+    Vector2 operator+(const ::Vector2& vector2) const { return Vector2Add(*this, vector2); }
 
     /**
      * Add two vectors (v1 + v2)
@@ -84,16 +71,12 @@ class Vector2 : public ::Vector2 {
     /**
      * Subtract two vectors (v1 - v2)
      */
-    Vector2 Subtract(const ::Vector2& vector2) const {
-        return Vector2Subtract(*this, vector2);
-    }
+    Vector2 Subtract(const ::Vector2& vector2) const { return Vector2Subtract(*this, vector2); }
 
     /**
      * Subtract two vectors (v1 - v2)
      */
-    Vector2 operator-(const ::Vector2& vector2) const {
-        return Vector2Subtract(*this, vector2);
-    }
+    Vector2 operator-(const ::Vector2& vector2) const { return Vector2Subtract(*this, vector2); }
 
     /**
      * Subtract two vectors (v1 - v2)
@@ -107,30 +90,22 @@ class Vector2 : public ::Vector2 {
     /**
      * Negate vector
      */
-    Vector2 Negate() const {
-        return Vector2Negate(*this);
-    }
+    Vector2 Negate() const { return Vector2Negate(*this); }
 
     /**
      * Negate vector
      */
-    Vector2 operator-() const {
-        return Vector2Negate(*this);
-    }
+    Vector2 operator-() const { return Vector2Negate(*this); }
 
     /**
      * Multiply vector by vector
      */
-    Vector2 Multiply(const ::Vector2& vector2) const {
-        return Vector2Multiply(*this, vector2);
-    }
+    Vector2 Multiply(const ::Vector2& vector2) const { return Vector2Multiply(*this, vector2); }
 
     /**
      * Multiply vector by vector
      */
-    Vector2 operator*(const ::Vector2& vector2) const {
-        return Vector2Multiply(*this, vector2);
-    }
+    Vector2 operator*(const ::Vector2& vector2) const { return Vector2Multiply(*this, vector2); }
 
     /**
      * Multiply vector by vector
@@ -144,16 +119,12 @@ class Vector2 : public ::Vector2 {
     /**
      * Scale vector (multiply by value)
      */
-    Vector2 Scale(const float scale) const {
-        return Vector2Scale(*this, scale);
-    }
+    Vector2 Scale(const float scale) const { return Vector2Scale(*this, scale); }
 
     /**
      * Scale vector (multiply by value)
      */
-    Vector2 operator*(const float scale) const {
-        return Vector2Scale(*this, scale);
-    }
+    Vector2 operator*(const float scale) const { return Vector2Scale(*this, scale); }
 
     /**
      * Scale vector (multiply by value)
@@ -167,16 +138,12 @@ class Vector2 : public ::Vector2 {
     /**
      * Divide vector by vector
      */
-    Vector2 Divide(const ::Vector2& vector2) const {
-        return Vector2Divide(*this, vector2);
-    }
+    Vector2 Divide(const ::Vector2& vector2) const { return Vector2Divide(*this, vector2); }
 
     /**
      * Divide vector by vector
      */
-    Vector2 operator/(const ::Vector2& vector2) const {
-        return Vector2Divide(*this, vector2);
-    }
+    Vector2 operator/(const ::Vector2& vector2) const { return Vector2Divide(*this, vector2); }
 
     /**
      * Divide vector by vector
@@ -190,16 +157,12 @@ class Vector2 : public ::Vector2 {
     /**
      * Divide vector by value
      */
-    Vector2 Divide(const float div) const {
-        return ::Vector2{x / div, y / div};
-    }
+    Vector2 Divide(const float div) const { return ::Vector2{x / div, y / div}; }
 
     /**
      * Divide vector by value
      */
-    Vector2 operator/(const float div) const {
-        return Divide(div);
-    }
+    Vector2 operator/(const float div) const { return Divide(div); }
 
     /**
      * Divide vector by value
@@ -214,37 +177,27 @@ class Vector2 : public ::Vector2 {
     /**
      * Normalize provided vector
      */
-    Vector2 Normalize() const {
-        return Vector2Normalize(*this);
-    }
+    Vector2 Normalize() const { return Vector2Normalize(*this); }
 
     /**
      * Transforms a Vector2 by a given Matrix
      */
-    Vector2 Transform(::Matrix mat) const {
-        return ::Vector2Transform(*this, mat);
-    }
+    Vector2 Transform(::Matrix mat) const { return ::Vector2Transform(*this, mat); }
 
     /**
      * Calculate linear interpolation between two vectors
      */
-    Vector2 Lerp(const ::Vector2& vector2, float amount) const {
-        return Vector2Lerp(*this, vector2, amount);
-    }
+    Vector2 Lerp(const ::Vector2& vector2, float amount) const { return Vector2Lerp(*this, vector2, amount); }
 
     /**
      * Calculate reflected vector to normal
      */
-    Vector2 Reflect(const ::Vector2& normal) const {
-        return Vector2Reflect(*this, normal);
-    }
+    Vector2 Reflect(const ::Vector2& normal) const { return Vector2Reflect(*this, normal); }
 
     /**
      * Rotate Vector by float in radians
      */
-    Vector2 Rotate(float angle) const {
-        return Vector2Rotate(*this, angle);
-    }
+    Vector2 Rotate(float angle) const { return Vector2Rotate(*this, angle); }
 
     /**
      * Move Vector towards target
@@ -256,95 +209,67 @@ class Vector2 : public ::Vector2 {
     /**
      * Invert the given vector
      */
-    Vector2 Invert() const {
-        return ::Vector2Invert(*this);
-    }
+    Vector2 Invert() const { return ::Vector2Invert(*this); }
 
     /**
      * Clamp the components of the vector between
      */
-    Vector2 Clamp(::Vector2 min, ::Vector2 max) const {
-        return ::Vector2Clamp(*this, min, max);
-    }
+    Vector2 Clamp(::Vector2 min, ::Vector2 max) const { return ::Vector2Clamp(*this, min, max); }
 
     /**
      * // Clamp the magnitude of the vector between two min and max values
      */
-    Vector2 Clamp(float min, float max) const {
-        return ::Vector2ClampValue(*this, min, max);
-    }
+    Vector2 Clamp(float min, float max) const { return ::Vector2ClampValue(*this, min, max); }
 
     /**
      * Check whether two given vectors are almost equal
      */
-    int Equals(::Vector2 q) const {
-        return ::Vector2Equals(*this, q);
-    }
+    int Equals(::Vector2 q) const { return ::Vector2Equals(*this, q); }
 
     /**
      * Calculate vector length
      */
-    float Length() const {
-        return Vector2Length(*this);
-    }
+    float Length() const { return Vector2Length(*this); }
 
     /**
      * Calculate vector square length
      */
-    float LengthSqr() const {
-        return Vector2LengthSqr(*this);
-    }
+    float LengthSqr() const { return Vector2LengthSqr(*this); }
 
     /**
      * Calculate two vectors dot product
      */
-    float DotProduct(const ::Vector2& vector2) const {
-        return Vector2DotProduct(*this, vector2);
-    }
+    float DotProduct(const ::Vector2& vector2) const { return Vector2DotProduct(*this, vector2); }
 
     /**
      * Calculate distance between two vectors
      */
-    float Distance(const ::Vector2& vector2) const {
-        return Vector2Distance(*this, vector2);
-    }
+    float Distance(const ::Vector2& vector2) const { return Vector2Distance(*this, vector2); }
 
     /**
      * Calculate square distance between two vectors
      */
-    float DistanceSqr(::Vector2 v2) const {
-        return ::Vector2DistanceSqr(*this, v2);
-    }
+    float DistanceSqr(::Vector2 v2) const { return ::Vector2DistanceSqr(*this, v2); }
 
     /**
      * Calculate angle from two vectors in X-axis
      */
-    float Angle(const ::Vector2& vector2) const {
-        return Vector2Angle(*this, vector2);
-    }
+    float Angle(const ::Vector2& vector2) const { return Vector2Angle(*this, vector2); }
 
     /**
      * Vector with components value 0.0f
      */
-    static Vector2 Zero() {
-        return Vector2Zero();
-    }
+    static Vector2 Zero() { return Vector2Zero(); }
 
     /**
      * Vector with components value 1.0f
      */
-    static Vector2 One() {
-        return Vector2One();
-    }
+    static Vector2 One() { return Vector2One(); }
 #endif
 
-    void DrawPixel(::Color color = {0, 0, 0, 255}) const {
-        ::DrawPixelV(*this, color);
-    }
+    void DrawPixel(::Color color = {0, 0, 0, 255}) const { ::DrawPixelV(*this, color); }
 
-    void DrawLine(::Vector2 endPos, ::Color color = {0, 0, 0, 255}) const {
-        ::DrawLineV(*this, endPos, color);
-    }
+    void DrawLine(::Vector2 endPos, ::Color color = {0, 0, 0, 255}) const { ::DrawLineV(*this, endPos, color); }
 
     void DrawLine(::Vector2 endPos, float thick, ::Color color = {0, 0, 0, 255}) const {
         ::DrawLineEx(*this, endPos, thick, color);
@@ -357,13 +282,9 @@ class Vector2 : public ::Vector2 {
     /**
      * Draw a color-filled circle (Vector version)
      */
-    void DrawCircle(float radius, ::Color color = {0, 0, 0, 255}) const {
-        ::DrawCircleV(*this, radius, color);
-    }
+    void DrawCircle(float radius, ::Color color = {0, 0, 0, 255}) const { ::DrawCircleV(*this, radius, color); }
 
-    void DrawRectangle(::Vector2 size, ::Color color = {0, 0, 0, 255}) const {
-        ::DrawRectangleV(*this, size, color);
-    }
+    void DrawRectangle(::Vector2 size, ::Color color = {0, 0, 0, 255}) const { ::DrawRectangleV(*this, size, color); }
 
     void DrawPoly(int sides, float radius, float rotation, ::Color color = {0, 0, 0, 255}) const {
         ::DrawPoly(*this, sides, radius, rotation, color);
@@ -386,9 +307,7 @@ class Vector2 : public ::Vector2 {
     /**
      * Check if point is inside rectangle
      */
-    bool CheckCollision(::Rectangle rec) const {
-        return ::CheckCollisionPointRec(*this, rec);
-    }
+    bool CheckCollision(::Rectangle rec) const { return ::CheckCollisionPointRec(*this, rec); }
 
     /**
      * Check if point is inside circle
@@ -407,10 +326,8 @@ class Vector2 : public ::Vector2 {
     /**
      * Check the collision between two lines defined by two points each, returns collision point by reference
      */
-    bool CheckCollisionLines(
-            ::Vector2 endPos1,
-            ::Vector2 startPos2, ::Vector2 endPos2,
-            ::Vector2 *collisionPoint) const {
+    bool
+    CheckCollisionLines(::Vector2 endPos1, ::Vector2 startPos2, ::Vector2 endPos2, ::Vector2* collisionPoint) const {
         return ::CheckCollisionLines(*this, endPos1, startPos2, endPos2, collisionPoint);
     }
 
@@ -420,16 +337,15 @@ class Vector2 : public ::Vector2 {
     bool CheckCollisionPointLine(::Vector2 p1, ::Vector2 p2, int threshold = 1) const {
         return ::CheckCollisionPointLine(*this, p1, p2, threshold);
     }
-
- protected:
+protected:
     void set(const ::Vector2& vec) {
         x = vec.x;
         y = vec.y;
     }
 };
 
-}  // namespace raylib
+} // namespace raylib
 
 using RVector2 = raylib::Vector2;
 
-#endif  // RAYLIB_CPP_INCLUDE_VECTOR2_HPP_
+#endif // RAYLIB_CPP_INCLUDE_VECTOR2_HPP_

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -7,16 +7,16 @@
 
 #include <string>
 
+#include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
 #include "./raymath.hpp"
-#include "./raylib-cpp-utils.hpp"
 
 namespace raylib {
 /**
  * Vector3 type
  */
 class Vector3 : public ::Vector3 {
- public:
+public:
     Vector3(const ::Vector3& vec) : ::Vector3{vec.x, vec.y, vec.z} {}
 
     Vector3(float x, float y, float z) : ::Vector3{x, y, z} {}
@@ -24,9 +24,7 @@ class Vector3 : public ::Vector3 {
     Vector3(float x) : ::Vector3{x, 0, 0} {}
     Vector3() {}
 
-    Vector3(::Color color) {
-        set(ColorToHSV(color));
-    }
+    Vector3(::Color color) { set(ColorToHSV(color)); }
 
     GETTERSETTER(float, X, x)
     GETTERSETTER(float, Y, y)
@@ -37,38 +35,24 @@ class Vector3 : public ::Vector3 {
         return *this;
     }
 
-    bool operator==(const ::Vector3& other) const {
-        return x == other.x
-            && y == other.y
-            && z == other.z;
-    }
+    bool operator==(const ::Vector3& other) const { return x == other.x && y == other.y && z == other.z; }
 
-    bool operator!=(const ::Vector3& other) const {
-        return !(*this == other);
-    }
+    bool operator!=(const ::Vector3& other) const { return !(*this == other); }
 
-    std::string ToString() const {
-        return TextFormat("Vector3(%f, %f, %f)", x, y, z);
-    }
+    std::string ToString() const { return TextFormat("Vector3(%f, %f, %f)", x, y, z); }
 
-    operator std::string() const {
-        return ToString();
-    }
+    operator std::string() const { return ToString(); }
 
 #ifndef RAYLIB_CPP_NO_MATH
     /**
      * Add two vectors
      */
-    Vector3 Add(const ::Vector3& vector3) const {
-        return Vector3Add(*this, vector3);
-    }
+    Vector3 Add(const ::Vector3& vector3) const { return Vector3Add(*this, vector3); }
 
     /**
      * Add two vectors
      */
-    Vector3 operator+(const ::Vector3& vector3) const {
-        return Vector3Add(*this, vector3);
-    }
+    Vector3 operator+(const ::Vector3& vector3) const { return Vector3Add(*this, vector3); }
 
     Vector3& operator+=(const ::Vector3& vector3) {
         set(Vector3Add(*this, vector3));
@@ -79,16 +63,12 @@ class Vector3 : public ::Vector3 {
     /**
      * Subtract two vectors.
      */
-    Vector3 Subtract(const ::Vector3& vector3) const {
-        return Vector3Subtract(*this, vector3);
-    }
+    Vector3 Subtract(const ::Vector3& vector3) const { return Vector3Subtract(*this, vector3); }
 
     /**
      * Subtract two vectors.
      */
-    Vector3 operator-(const ::Vector3& vector3) const {
-        return Vector3Subtract(*this, vector3);
-    }
+    Vector3 operator-(const ::Vector3& vector3) const { return Vector3Subtract(*this, vector3); }
 
     Vector3& operator-=(const ::Vector3& vector3) {
         set(Vector3Subtract(*this, vector3));
@@ -99,30 +79,22 @@ class Vector3 : public ::Vector3 {
     /**
      * Negate provided vector (invert direction)
      */
-    Vector3 Negate() const {
-        return Vector3Negate(*this);
-    }
+    Vector3 Negate() const { return Vector3Negate(*this); }
 
     /**
      * Negate provided vector (invert direction)
      */
-    Vector3 operator-() const {
-        return Vector3Negate(*this);
-    }
+    Vector3 operator-() const { return Vector3Negate(*this); }
 
     /**
      * Multiply vector by vector
      */
-    Vector3 Multiply(const ::Vector3& vector3) const {
-        return Vector3Multiply(*this, vector3);
-    }
+    Vector3 Multiply(const ::Vector3& vector3) const { return Vector3Multiply(*this, vector3); }
 
     /**
      * Multiply vector by vector
      */
-    Vector3 operator*(const ::Vector3& vector3) const {
-        return Vector3Multiply(*this, vector3);
-    }
+    Vector3 operator*(const ::Vector3& vector3) const { return Vector3Multiply(*this, vector3); }
 
     /**
      * Multiply vector by vector
@@ -136,16 +108,12 @@ class Vector3 : public ::Vector3 {
     /**
      * Multiply vector by scalar
      */
-    Vector3 Scale(const float scaler) const {
-        return Vector3Scale(*this, scaler);
-    }
+    Vector3 Scale(const float scaler) const { return Vector3Scale(*this, scaler); }
 
     /**
      * Multiply vector by scalar
      */
-    Vector3 operator*(const float scaler) const {
-        return Vector3Scale(*this, scaler);
-    }
+    Vector3 operator*(const float scaler) const { return Vector3Scale(*this, scaler); }
 
     /**
      * Multiply vector by scalar
@@ -159,16 +127,12 @@ class Vector3 : public ::Vector3 {
     /**
      * Divide vector by vector
      */
-    Vector3 Divide(const ::Vector3& vector3) const {
-        return Vector3Divide(*this, vector3);
-    }
+    Vector3 Divide(const ::Vector3& vector3) const { return Vector3Divide(*this, vector3); }
 
     /**
      * Divide vector by vector
      */
-    Vector3 operator/(const ::Vector3& vector3) const {
-        return Vector3Divide(*this, vector3);
-    }
+    Vector3 operator/(const ::Vector3& vector3) const { return Vector3Divide(*this, vector3); }
 
     /**
      * Divide vector by vector
@@ -184,16 +148,12 @@ class Vector3 : public ::Vector3 {
     /**
      * Divide a vector by a value.
      */
-    Vector3 Divide(const float div) const {
-        return ::Vector3{x / div, y / div, z / div};
-    }
+    Vector3 Divide(const float div) const { return ::Vector3{x / div, y / div, z / div}; }
 
     /**
      * Divide a vector by a value.
      */
-    Vector3 operator/(const float div) const {
-        return Divide(div);
-    }
+    Vector3 operator/(const float div) const { return Divide(div); }
 
     /**
      * Divide a vector by a value.
@@ -209,99 +169,57 @@ class Vector3 : public ::Vector3 {
     /**
      * Calculate vector length
      */
-    float Length() const {
-        return Vector3Length(*this);
-    }
+    float Length() const { return Vector3Length(*this); }
 
     /**
      * Calculate vector square length
      */
-    float LengthSqr() const {
-        return Vector3LengthSqr(*this);
-    }
+    float LengthSqr() const { return Vector3LengthSqr(*this); }
 
-    Vector3 Normalize() const {
-        return Vector3Normalize(*this);
-    }
+    Vector3 Normalize() const { return Vector3Normalize(*this); }
 
-    float DotProduct(const ::Vector3& vector3) const {
-        return Vector3DotProduct(*this, vector3);
-    }
+    float DotProduct(const ::Vector3& vector3) const { return Vector3DotProduct(*this, vector3); }
 
-    float Distance(const ::Vector3& vector3) const {
-        return Vector3Distance(*this, vector3);
-    }
+    float Distance(const ::Vector3& vector3) const { return Vector3Distance(*this, vector3); }
 
-    Vector3 Lerp(const ::Vector3& vector3, const float amount) const {
-        return Vector3Lerp(*this, vector3, amount);
-    }
+    Vector3 Lerp(const ::Vector3& vector3, const float amount) const { return Vector3Lerp(*this, vector3, amount); }
 
-    Vector3 CrossProduct(const ::Vector3& vector3) const {
-        return Vector3CrossProduct(*this, vector3);
-    }
+    Vector3 CrossProduct(const ::Vector3& vector3) const { return Vector3CrossProduct(*this, vector3); }
 
-    Vector3 Perpendicular() const {
-        return Vector3Perpendicular(*this);
-    }
+    Vector3 Perpendicular() const { return Vector3Perpendicular(*this); }
 
-    Vector3 Project(const ::Vector3& vector3) const {
-        return Vector3Project(*this, vector3);
-    }
+    Vector3 Project(const ::Vector3& vector3) const { return Vector3Project(*this, vector3); }
 
-    Vector3 Reject(const ::Vector3& vector3) const {
-        return Vector3Reject(*this, vector3);
-    }
+    Vector3 Reject(const ::Vector3& vector3) const { return Vector3Reject(*this, vector3); }
 
-    void OrthoNormalize(::Vector3* vector3) {
-        Vector3OrthoNormalize(this, vector3);
-    }
+    void OrthoNormalize(::Vector3* vector3) { Vector3OrthoNormalize(this, vector3); }
 
-    Vector3 Transform(const ::Matrix& matrix) const {
-        return Vector3Transform(*this, matrix);
-    }
+    Vector3 Transform(const ::Matrix& matrix) const { return Vector3Transform(*this, matrix); }
 
     Vector3 RotateByQuaternion(const ::Quaternion& quaternion) const {
         return Vector3RotateByQuaternion(*this, quaternion);
     }
 
-    Vector3 Reflect(const ::Vector3& normal) const {
-        return Vector3Reflect(*this, normal);
-    }
+    Vector3 Reflect(const ::Vector3& normal) const { return Vector3Reflect(*this, normal); }
 
-    Vector3 Min(const ::Vector3& vector3) const {
-        return Vector3Min(*this, vector3);
-    }
+    Vector3 Min(const ::Vector3& vector3) const { return Vector3Min(*this, vector3); }
 
-    Vector3 Max(const ::Vector3& vector3) const {
-        return Vector3Max(*this, vector3);
-    }
+    Vector3 Max(const ::Vector3& vector3) const { return Vector3Max(*this, vector3); }
 
     Vector3 Barycenter(const ::Vector3& a, const ::Vector3& b, const ::Vector3& c) const {
         return Vector3Barycenter(*this, a, b, c);
     }
 
-    static Vector3 Zero() {
-        return Vector3Zero();
-    }
+    static Vector3 Zero() { return Vector3Zero(); }
 
-    static Vector3 One() {
-        return Vector3One();
-    }
+    static Vector3 One() { return Vector3One(); }
 #endif
 
-    void DrawLine3D(const ::Vector3& endPos, ::Color color) const {
-        ::DrawLine3D(*this, endPos, color);
-    }
+    void DrawLine3D(const ::Vector3& endPos, ::Color color) const { ::DrawLine3D(*this, endPos, color); }
 
-    void DrawPoint3D(::Color color) const {
-        ::DrawPoint3D(*this, color);
-    }
+    void DrawPoint3D(::Color color) const { ::DrawPoint3D(*this, color); }
 
-    void DrawCircle3D(
-            float radius,
-            const ::Vector3& rotationAxis,
-            float rotationAngle,
-            Color color) const {
+    void DrawCircle3D(float radius, const ::Vector3& rotationAxis, float rotationAngle, Color color) const {
         ::DrawCircle3D(*this, radius, rotationAxis, rotationAngle, color);
     }
 
@@ -309,21 +227,15 @@ class Vector3 : public ::Vector3 {
         ::DrawCube(*this, width, height, length, color);
     }
 
-    void DrawCube(const ::Vector3& size, ::Color color) const {
-        ::DrawCubeV(*this, size, color);
-    }
+    void DrawCube(const ::Vector3& size, ::Color color) const { ::DrawCubeV(*this, size, color); }
 
     void DrawCubeWires(float width, float height, float length, ::Color color) const {
         ::DrawCubeWires(*this, width, height, length, color);
     }
 
-    void DrawCubeWires(const ::Vector3& size, ::Color color) const {
-        ::DrawCubeWiresV(*this, size, color);
-    }
+    void DrawCubeWires(const ::Vector3& size, ::Color color) const { ::DrawCubeWiresV(*this, size, color); }
 
-    void DrawSphere(float radius, ::Color color) const {
-        ::DrawSphere(*this, radius, color);
-    }
+    void DrawSphere(float radius, ::Color color) const { ::DrawSphere(*this, radius, color); }
 
     void DrawSphere(float radius, int rings, int slices, ::Color color) const {
         ::DrawSphereEx(*this, radius, rings, slices, color);
@@ -333,19 +245,15 @@ class Vector3 : public ::Vector3 {
         ::DrawSphereWires(*this, radius, rings, slices, color);
     }
 
-    void DrawCylinder(float radiusTop, float radiusBottom, float height,
-            int slices, ::Color color) const {
+    void DrawCylinder(float radiusTop, float radiusBottom, float height, int slices, ::Color color) const {
         ::DrawCylinder(*this, radiusTop, radiusBottom, height, slices, color);
     }
 
-    void DrawCylinderWires(float radiusTop, float radiusBottom, float height,
-            int slices, ::Color color) const {
+    void DrawCylinderWires(float radiusTop, float radiusBottom, float height, int slices, ::Color color) const {
         ::DrawCylinderWires(*this, radiusTop, radiusBottom, height, slices, color);
     }
 
-    void DrawPlane(const ::Vector2& size, ::Color color) const {
-        ::DrawPlane(*this, size, color);
-    }
+    void DrawPlane(const ::Vector2& size, ::Color color) const { ::DrawPlane(*this, size, color); }
 
     /**
      * Detect collision between two spheres
@@ -353,16 +261,15 @@ class Vector3 : public ::Vector3 {
     bool CheckCollision(float radius1, const ::Vector3& center2, float radius2) const {
         return CheckCollisionSpheres(*this, radius1, center2, radius2);
     }
-
- protected:
+protected:
     void set(const ::Vector3& vec) {
         x = vec.x;
         y = vec.y;
         z = vec.z;
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RVector3 = raylib::Vector3;
 
-#endif  // RAYLIB_CPP_INCLUDE_VECTOR3_HPP_
+#endif // RAYLIB_CPP_INCLUDE_VECTOR3_HPP_

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -8,16 +8,16 @@
 
 #include <string>
 
+#include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
 #include "./raymath.hpp"
-#include "./raylib-cpp-utils.hpp"
 
 namespace raylib {
 /**
  * Vector4 type
  */
 class Vector4 : public ::Vector4 {
- public:
+public:
     Vector4(const ::Vector4& vec) : ::Vector4{vec.x, vec.y, vec.z, vec.w} {}
 
     Vector4(float x, float y, float z, float w) : ::Vector4{x, y, z, w} {}
@@ -27,9 +27,7 @@ class Vector4 : public ::Vector4 {
     Vector4() : ::Vector4{0, 0, 0, 0} {}
     Vector4(::Rectangle rectangle) : ::Vector4{rectangle.x, rectangle.y, rectangle.width, rectangle.height} {}
 
-    Vector4(::Color color) {
-        set(ColorNormalize(color));
-    }
+    Vector4(::Color color) { set(ColorNormalize(color)); }
 
     GETTERSETTER(float, X, x)
     GETTERSETTER(float, Y, y)
@@ -42,72 +40,39 @@ class Vector4 : public ::Vector4 {
     }
 
     bool operator==(const ::Vector4& other) const {
-        return x == other.x
-            && y == other.y
-            && z == other.z
-            && w == other.w;
+        return x == other.x && y == other.y && z == other.z && w == other.w;
     }
 
-    bool operator!=(const ::Vector4& other) const {
-        return !(*this == other);
-    }
+    bool operator!=(const ::Vector4& other) const { return !(*this == other); }
 
-    ::Rectangle ToRectangle() const {
-        return {x, y, z, w};
-    }
+    ::Rectangle ToRectangle() const { return {x, y, z, w}; }
 
-    operator ::Rectangle() const {
-        return {x, y, z, w};
-    }
+    operator ::Rectangle() const { return {x, y, z, w}; }
 
-    std::string ToString() const {
-        return TextFormat("Vector4(%f, %f, %f, %f)", x, y, z, w);
-    }
+    std::string ToString() const { return TextFormat("Vector4(%f, %f, %f, %f)", x, y, z, w); }
 
-    operator std::string() const {
-        return ToString();
-    }
+    operator std::string() const { return ToString(); }
 
 #ifndef RAYLIB_CPP_NO_MATH
-    Vector4 Multiply(const ::Vector4& vector4) const {
-        return QuaternionMultiply(*this, vector4);
-    }
+    Vector4 Multiply(const ::Vector4& vector4) const { return QuaternionMultiply(*this, vector4); }
 
-    Vector4 operator*(const ::Vector4& vector4) const {
-        return QuaternionMultiply(*this, vector4);
-    }
+    Vector4 operator*(const ::Vector4& vector4) const { return QuaternionMultiply(*this, vector4); }
 
-    Vector4 Lerp(const ::Vector4& vector4, float amount) const {
-        return QuaternionLerp(*this, vector4, amount);
-    }
+    Vector4 Lerp(const ::Vector4& vector4, float amount) const { return QuaternionLerp(*this, vector4, amount); }
 
-    Vector4 Nlerp(const ::Vector4& vector4, float amount) const {
-        return QuaternionNlerp(*this, vector4, amount);
-    }
+    Vector4 Nlerp(const ::Vector4& vector4, float amount) const { return QuaternionNlerp(*this, vector4, amount); }
 
-    Vector4 Slerp(const ::Vector4& vector4, float amount) const {
-        return QuaternionSlerp(*this, vector4, amount);
-    }
+    Vector4 Slerp(const ::Vector4& vector4, float amount) const { return QuaternionSlerp(*this, vector4, amount); }
 
-    Matrix ToMatrix() const {
-        return QuaternionToMatrix(*this);
-    }
+    Matrix ToMatrix() const { return QuaternionToMatrix(*this); }
 
-    float Length() const {
-        return QuaternionLength(*this);
-    }
+    float Length() const { return QuaternionLength(*this); }
 
-    Vector4 Normalize() const {
-        return QuaternionNormalize(*this);
-    }
+    Vector4 Normalize() const { return QuaternionNormalize(*this); }
 
-    Vector4 Invert() const {
-        return QuaternionInvert(*this);
-    }
+    Vector4 Invert() const { return QuaternionInvert(*this); }
 
-    void ToAxisAngle(::Vector3 *outAxis, float *outAngle) const {
-        QuaternionToAxisAngle(*this, outAxis, outAngle);
-    }
+    void ToAxisAngle(::Vector3* outAxis, float* outAngle) const { QuaternionToAxisAngle(*this, outAxis, outAngle); }
 
     /**
      * Get the rotation angle and axis for a given quaternion
@@ -120,21 +85,15 @@ class Vector4 : public ::Vector4 {
         return std::pair<Vector3, float>(outAxis, outAngle);
     }
 
-    Vector4 Transform(const ::Matrix& matrix) const {
-        return ::QuaternionTransform(*this, matrix);
+    Vector4 Transform(const ::Matrix& matrix) const { return ::QuaternionTransform(*this, matrix); }
+
+    static Vector4 Identity() { return ::QuaternionIdentity(); }
+
+    static Vector4 FromVector3ToVector3(const ::Vector3& from, const ::Vector3& to) {
+        return ::QuaternionFromVector3ToVector3(from, to);
     }
 
-    static Vector4 Identity() {
-        return ::QuaternionIdentity();
-    }
-
-    static Vector4 FromVector3ToVector3(const ::Vector3& from , const ::Vector3& to) {
-        return ::QuaternionFromVector3ToVector3(from , to);
-    }
-
-    static Vector4 FromMatrix(const ::Matrix& matrix) {
-        return ::QuaternionFromMatrix(matrix);
-    }
+    static Vector4 FromMatrix(const ::Matrix& matrix) { return ::QuaternionFromMatrix(matrix); }
 
     static Vector4 FromAxisAngle(const ::Vector3& axis, const float angle) {
         return ::QuaternionFromAxisAngle(axis, angle);
@@ -148,20 +107,13 @@ class Vector4 : public ::Vector4 {
         return ::QuaternionFromEuler(vector3.x, vector3.y, vector3.z);
     }
 
-    Vector3 ToEuler() const {
-        return ::QuaternionToEuler(*this);
-    }
+    Vector3 ToEuler() const { return ::QuaternionToEuler(*this); }
 #endif
 
-    Color ColorFromNormalized() const {
-        return ::ColorFromNormalized(*this);
-    }
+    Color ColorFromNormalized() const { return ::ColorFromNormalized(*this); }
 
-    operator Color() const {
-        return ColorFromNormalized();
-    }
-
- protected:
+    operator Color() const { return ColorFromNormalized(); }
+protected:
     void set(const ::Vector4& vec4) {
         x = vec4.x;
         y = vec4.y;
@@ -173,9 +125,9 @@ class Vector4 : public ::Vector4 {
 // Alias the Vector4 as Quaternion.
 using Quaternion = Vector4;
 
-}  // namespace raylib
+} // namespace raylib
 
 using RVector4 = raylib::Vector4;
 using RQuaternion = raylib::Quaternion;
 
-#endif  // RAYLIB_CPP_INCLUDE_VECTOR4_HPP_
+#endif // RAYLIB_CPP_INCLUDE_VECTOR4_HPP_

--- a/include/VrStereoConfig.hpp
+++ b/include/VrStereoConfig.hpp
@@ -1,32 +1,26 @@
 #ifndef RAYLIB_CPP_INCLUDE_VRSTEREOCONFIG_HPP_
 #define RAYLIB_CPP_INCLUDE_VRSTEREOCONFIG_HPP_
 
-#include "./raylib.hpp"
 #include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * VR stereo config functions for VR simulator
  */
-class VrStereoConfig : public ::VrStereoConfig  {
- public:
-    VrStereoConfig(const ::VrDeviceInfo& info) {
-        Load(info);
-    }
+class VrStereoConfig : public ::VrStereoConfig {
+public:
+    VrStereoConfig(const ::VrDeviceInfo& info) { Load(info); }
 
     /**
      * Load VR stereo config for VR simulator device parameters
      */
-    void Load(const ::VrDeviceInfo& info) {
-        set(LoadVrStereoConfig(info));
-    }
+    void Load(const ::VrDeviceInfo& info) { set(LoadVrStereoConfig(info)); }
 
     /**
      * Unload VR stereo config
      */
-    ~VrStereoConfig() {
-        Unload();
-    }
+    ~VrStereoConfig() { Unload(); }
 
     /**
      * Begin stereo rendering
@@ -47,11 +41,8 @@ class VrStereoConfig : public ::VrStereoConfig  {
     /**
      * Unload VR stereo config
      */
-    void Unload() {
-        ::UnloadVrStereoConfig(*this);
-    }
-
- protected:
+    void Unload() { ::UnloadVrStereoConfig(*this); }
+protected:
     void set(const ::VrStereoConfig& config) {
         projection[0] = config.projection[0];
         projection[1] = config.projection[1];
@@ -71,8 +62,8 @@ class VrStereoConfig : public ::VrStereoConfig  {
         scaleIn[1] = config.scaleIn[1];
     }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RVrStereoConfig = raylib::VrStereoConfig;
 
-#endif  // RAYLIB_CPP_INCLUDE_VRSTEREOCONFIG_HPP_
+#endif // RAYLIB_CPP_INCLUDE_VRSTEREOCONFIG_HPP_

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -3,26 +3,25 @@
 
 #include <string>
 
-#include "./raylib.hpp"
-#include "./raylib-cpp-utils.hpp"
 #include "./RaylibException.hpp"
+#include "./raylib-cpp-utils.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Wave type, defines audio wave data
  */
 class Wave : public ::Wave {
- public:
-    Wave(const ::Wave& wave) {
-        set(wave);
-    }
+public:
+    Wave(const ::Wave& wave) { set(wave); }
 
     Wave(
-            unsigned int frameCount = 0,
-            unsigned int sampleRate = 0,
-            unsigned int sampleSize = 0,
-            unsigned int channels = 0,
-            void *data = nullptr) : ::Wave{frameCount, sampleRate, sampleSize, channels, data} {
+        unsigned int frameCount = 0,
+        unsigned int sampleRate = 0,
+        unsigned int sampleSize = 0,
+        unsigned int channels = 0,
+        void* data = nullptr)
+        : ::Wave{frameCount, sampleRate, sampleSize, channels, data} {
         // Nothing.
     }
 
@@ -31,22 +30,18 @@ class Wave : public ::Wave {
      *
      * @throws raylib::RaylibException Throws if the Wave failed to load.
      */
-    Wave(const std::string& fileName) {
-        Load(fileName);
-    }
+    Wave(const std::string& fileName) { Load(fileName); }
 
     /**
      * Load wave from memory buffer, fileType refers to extension: i.e. "wav"
      *
      * @throws raylib::RaylibException Throws if the Wave failed to load.
      */
-    Wave(const std::string& fileType, const unsigned char *fileData, int dataSize) {
+    Wave(const std::string& fileType, const unsigned char* fileData, int dataSize) {
         Load(fileType, fileData, dataSize);
     }
 
-    Wave(const Wave& other) {
-        set(other.Copy());
-    }
+    Wave(const Wave& other) { set(other.Copy()); }
 
     Wave(Wave&& other) {
         set(other);
@@ -61,15 +56,13 @@ class Wave : public ::Wave {
     /**
      * Unload wave data
      */
-    ~Wave() {
-        Unload();
-    }
+    ~Wave() { Unload(); }
 
     GETTER(unsigned int, FrameCount, frameCount)
     GETTER(unsigned int, SampleRate, sampleRate)
     GETTER(unsigned int, SampleSize, sampleSize)
     GETTER(unsigned int, Channels, channels)
-    GETTER(void *, Data, data)
+    GETTER(void*, Data, data)
 
     Wave& operator=(const ::Wave& wave) {
         set(wave);
@@ -107,9 +100,7 @@ class Wave : public ::Wave {
     /**
      * Copy a wave to a new wave
      */
-    ::Wave Copy() const {
-        return ::WaveCopy(*this);
-    }
+    ::Wave Copy() const { return ::WaveCopy(*this); }
 
     /**
      * Crop a wave to defined samples range
@@ -130,16 +121,12 @@ class Wave : public ::Wave {
     /**
      * Load samples data from wave as a floats array
      */
-    float* LoadSamples() {
-        return ::LoadWaveSamples(*this);
-    }
+    float* LoadSamples() { return ::LoadWaveSamples(*this); }
 
     /**
      * Unload samples data loaded with LoadWaveSamples()
      */
-    static void UnloadSamples(float *samples) {
-        ::UnloadWaveSamples(samples);
-    }
+    static void UnloadSamples(float* samples) { ::UnloadWaveSamples(samples); }
 
     /**
      * Export wave data to file, returns true on success
@@ -171,16 +158,12 @@ class Wave : public ::Wave {
     /**
      * Load sound from wave data
      */
-    ::Sound LoadSound() {
-        return ::LoadSoundFromWave(*this);
-    }
+    ::Sound LoadSound() { return ::LoadSoundFromWave(*this); }
 
     /**
      * Load sound from wave data
      */
-    operator ::Sound() {
-        return LoadSound();
-    }
+    operator ::Sound() { return LoadSound(); }
 
     /**
      * Load wave data from file.
@@ -199,7 +182,7 @@ class Wave : public ::Wave {
      *
      * @throws raylib::RaylibException Throws if the Wave failed to load.
      */
-    void Load(const std::string& fileType, const unsigned char *fileData, int dataSize) {
+    void Load(const std::string& fileType, const unsigned char* fileData, int dataSize) {
         set(::LoadWaveFromMemory(fileType.c_str(), fileData, dataSize));
         if (!IsReady()) {
             throw RaylibException("Failed to load Wave from file data of type: " + fileType);
@@ -211,11 +194,8 @@ class Wave : public ::Wave {
      *
      * @return True or false depending on whether the wave data has been loaded.
      */
-    bool IsReady() const {
-        return ::IsWaveReady(*this);
-    }
-
- protected:
+    bool IsReady() const { return ::IsWaveReady(*this); }
+protected:
     void set(const ::Wave& wave) {
         frameCount = wave.frameCount;
         sampleRate = wave.sampleRate;
@@ -225,8 +205,8 @@ class Wave : public ::Wave {
     }
 };
 
-}  // namespace raylib
+} // namespace raylib
 
 using RWave = raylib::Wave;
 
-#endif  // RAYLIB_CPP_INCLUDE_WAVE_HPP_
+#endif // RAYLIB_CPP_INCLUDE_WAVE_HPP_

--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -3,16 +3,16 @@
 
 #include <string>
 
-#include "./raylib.hpp"
 #include "./RaylibException.hpp"
 #include "./Vector2.hpp"
+#include "./raylib.hpp"
 
 namespace raylib {
 /**
  * Window and Graphics Device Functions.
  */
 class Window {
- public:
+public:
     /**
      * Build a Window object, but defer the initialization. Ensure you call Init() manually.
      *
@@ -42,9 +42,7 @@ class Window {
     /**
      * Close window and unload OpenGL context
      */
-    ~Window() {
-        Close();
-    }
+    ~Window() { Close(); }
 
     /**
      * Initializes the window.
@@ -72,16 +70,12 @@ class Window {
     /**
      * Check if KEY_ESCAPE pressed or Close icon pressed
      */
-    bool ShouldClose() const {
-        return ::WindowShouldClose();
-    }
+    bool ShouldClose() const { return ::WindowShouldClose(); }
 
     /**
      * Set a custom key to exit program (default is ESC)
      */
-    void SetExitKey(int key) {
-        ::SetExitKey(key);
-    }
+    void SetExitKey(int key) { ::SetExitKey(key); }
 
     /**
      * Close window and unload OpenGL context
@@ -95,58 +89,42 @@ class Window {
     /**
      * Check if cursor is on the current screen
      */
-    bool IsCursorOnScreen() const {
-        return ::IsCursorOnScreen();
-    }
+    bool IsCursorOnScreen() const { return ::IsCursorOnScreen(); }
 
     /**
      * Check if window is currently fullscreen
      */
-    bool IsFullscreen() const {
-        return ::IsWindowFullscreen();
-    }
+    bool IsFullscreen() const { return ::IsWindowFullscreen(); }
 
     /**
      * Check if window is currently hidden
      */
-    bool IsHidden() const {
-        return ::IsWindowHidden();
-    }
+    bool IsHidden() const { return ::IsWindowHidden(); }
 
     /**
      * Check if window is currently minimized
      */
-    bool IsMinimized() const {
-        return ::IsWindowMinimized();
-    }
+    bool IsMinimized() const { return ::IsWindowMinimized(); }
 
     /**
      * Check if window is currently minimized
      */
-    bool IsMaximized() const {
-        return ::IsWindowMaximized();
-    }
+    bool IsMaximized() const { return ::IsWindowMaximized(); }
 
     /**
      * Check if window is currently focused
      */
-    bool IsFocused() const {
-        return ::IsWindowFocused();
-    }
+    bool IsFocused() const { return ::IsWindowFocused(); }
 
     /**
      * Check if window has been resized last frame
      */
-    bool IsResized() const {
-        return ::IsWindowResized();
-    }
+    bool IsResized() const { return ::IsWindowResized(); }
 
     /**
      * Check if one specific window flag is enabled
      */
-    bool IsState(unsigned int flag) const {
-        return ::IsWindowState(flag);
-    }
+    bool IsState(unsigned int flag) const { return ::IsWindowState(flag); }
 
     /**
      * Set window configuration state using flags
@@ -188,7 +166,8 @@ class Window {
             if (!IsFullscreen()) {
                 ToggleFullscreen();
             }
-        } else {
+        }
+        else {
             if (IsFullscreen()) {
                 ToggleFullscreen();
             }
@@ -199,7 +178,7 @@ class Window {
 
     /**
      * Toggle window state: borderless/windowed
-    */
+     */
     Window& ToggleBorderless() {
         ::ToggleBorderlessWindowed();
         return *this;
@@ -319,23 +298,17 @@ class Window {
     /**
      * Set window dimensions
      */
-    Window& SetSize(const ::Vector2& size) {
-        return SetSize(static_cast<int>(size.x), static_cast<int>(size.y));
-    }
+    Window& SetSize(const ::Vector2& size) { return SetSize(static_cast<int>(size.x), static_cast<int>(size.y)); }
 
     /**
      * Get the screen's width and height.
      */
-    Vector2 GetSize() const {
-        return {static_cast<float>(GetWidth()), static_cast<float>(GetHeight())};
-    }
+    Vector2 GetSize() const { return {static_cast<float>(GetWidth()), static_cast<float>(GetHeight())}; }
 
     /**
      * Get native window handle
      */
-    void* GetHandle() const {
-        return ::GetWindowHandle();
-    }
+    void* GetHandle() const { return ::GetWindowHandle(); }
 
     /**
      * Setup canvas (framebuffer) to start drawing
@@ -356,58 +329,42 @@ class Window {
     /**
      * Get current screen width
      */
-    int GetWidth() const {
-        return ::GetScreenWidth();
-    }
+    int GetWidth() const { return ::GetScreenWidth(); }
 
     /**
      * Get current screen height
      */
-    int GetHeight() const {
-        return ::GetScreenHeight();
-    }
+    int GetHeight() const { return ::GetScreenHeight(); }
 
     /**
      * Get current render width (it considers HiDPI)
      */
-    int GetRenderWidth() const {
-        return ::GetRenderWidth();
-    }
+    int GetRenderWidth() const { return ::GetRenderWidth(); }
 
     /**
      * Get current render height (it considers HiDPI)
      */
-    int GetRenderHeight() const {
-        return ::GetRenderHeight();
-    }
+    int GetRenderHeight() const { return ::GetRenderHeight(); }
 
     /**
      * Get window position XY on monitor
      */
-    Vector2 GetPosition() const {
-        return ::GetWindowPosition();
-    }
+    Vector2 GetPosition() const { return ::GetWindowPosition(); }
 
     /**
      * Get window scale DPI factor
      */
-    Vector2 GetScaleDPI() const {
-        return ::GetWindowScaleDPI();
-    }
+    Vector2 GetScaleDPI() const { return ::GetWindowScaleDPI(); }
 
     /**
      * Set clipboard text content
      */
-    void SetClipboardText(const std::string& text) {
-        ::SetClipboardText(text.c_str());
-    }
+    void SetClipboardText(const std::string& text) { ::SetClipboardText(text.c_str()); }
 
     /**
      * Get clipboard text content
      */
-    const std::string GetClipboardText() {
-        return ::GetClipboardText();
-    }
+    const std::string GetClipboardText() { return ::GetClipboardText(); }
 
     /**
      * Set target FPS (maximum)
@@ -420,37 +377,27 @@ class Window {
     /**
      * Returns current FPS
      */
-    int GetFPS() const {
-        return ::GetFPS();
-    }
+    int GetFPS() const { return ::GetFPS(); }
 
     /**
      * Draw current FPS
      */
-    void DrawFPS(int posX = 10, int posY = 10) const {
-        ::DrawFPS(posX, posY);
-    }
+    void DrawFPS(int posX = 10, int posY = 10) const { ::DrawFPS(posX, posY); }
 
     /**
      * Returns time in seconds for last frame drawn
      */
-    float GetFrameTime() const {
-        return ::GetFrameTime();
-    }
+    float GetFrameTime() const { return ::GetFrameTime(); }
 
     /**
      * Returns elapsed time in seconds since InitWindow()
      */
-    double GetTime() const {
-        return ::GetTime();
-    }
+    double GetTime() const { return ::GetTime(); }
 
     /**
      * Check if window has been initialized successfully
      */
-    static bool IsReady() {
-        return ::IsWindowReady();
-    }
+    static bool IsReady() { return ::IsWindowReady(); }
 
     /**
      * Sets the configuration flags for raylib.
@@ -459,12 +406,10 @@ class Window {
      *
      * @see ::SetConfigFlags
      */
-    void SetConfigFlags(unsigned int flags) {
-        ::SetConfigFlags(flags);
-    }
+    void SetConfigFlags(unsigned int flags) { ::SetConfigFlags(flags); }
 };
-}  // namespace raylib
+} // namespace raylib
 
 using RWindow = raylib::Window;
 
-#endif  // RAYLIB_CPP_INCLUDE_WINDOW_HPP_
+#endif // RAYLIB_CPP_INCLUDE_WINDOW_HPP_

--- a/include/raylib-cpp-utils.hpp
+++ b/include/raylib-cpp-utils.hpp
@@ -12,9 +12,11 @@
  * @param method The human-readable name for the method.
  * @param name The machine-readable name of the property.
  */
-#define GETTER(type, method, name) \
+#define GETTER(type, method, name)                                                        \
     /** Retrieves the name value for the object. @return The name value of the object. */ \
-    type Get##method() const { return name; }
+    type Get##method() const {                                                            \
+        return name;                                                                      \
+    }
 #endif
 
 #ifndef GETTERSETTER
@@ -25,10 +27,12 @@
  * @param method The human-readable name for the method.
  * @param name The machine-readable name of the property.
  */
-#define GETTERSETTER(type, method, name) \
-    GETTER(type, method, name) \
+#define GETTERSETTER(type, method, name)                                                       \
+    GETTER(type, method, name)                                                                 \
     /** Sets the name value for the object. @param value The value of which to set name to. */ \
-    void Set##method(type value) { name = value; }
+    void Set##method(type value) {                                                             \
+        name = value;                                                                          \
+    }
 #endif
 
-#endif  // RAYLIB_CPP_INCLUDE_RAYLIB_CPP_UTILS_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RAYLIB_CPP_UTILS_HPP_

--- a/include/raylib-cpp.hpp
+++ b/include/raylib-cpp.hpp
@@ -53,8 +53,8 @@
 #include "./Mouse.hpp"
 #include "./Music.hpp"
 #include "./Ray.hpp"
-#include "./RaylibException.hpp"
 #include "./RayCollision.hpp"
+#include "./RaylibException.hpp"
 #include "./Rectangle.hpp"
 #include "./RenderTexture.hpp"
 #include "./Shader.hpp"
@@ -74,7 +74,7 @@
  * All raylib-cpp classes and functions appear in the raylib namespace.
  */
 namespace raylib {
-    // Nothing.
-}  // namespace raylib
+// Nothing.
+} // namespace raylib
 
-#endif  // RAYLIB_CPP_INCLUDE_RAYLIB_CPP_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RAYLIB_CPP_HPP_

--- a/include/raylib.hpp
+++ b/include/raylib.hpp
@@ -15,19 +15,19 @@ extern "C" {
 #include RAYLIB_H_FILE // NOLINT
 
 #if !defined(RAYLIB_VERSION_MAJOR) || !defined(RAYLIB_VERSION_MINOR)
-    #error "raylib-cpp requires raylib >= 5"
+#error "raylib-cpp requires raylib >= 5"
 #endif
 
 #if RAYLIB_VERSION_MAJOR < 5
-    #error "raylib-cpp requires raylib >= 5"
+#error "raylib-cpp requires raylib >= 5"
 #endif
 
 #if RAYLIB_VERSION_MAJOR > 5
-    #error "raylib-cpp requires raylib ~5.0. Use the `next` branch for the next version of raylib."
+#error "raylib-cpp requires raylib ~5.0. Use the `next` branch for the next version of raylib."
 #endif
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // RAYLIB_CPP_INCLUDE_RAYLIB_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RAYLIB_HPP_

--- a/include/raymath.hpp
+++ b/include/raymath.hpp
@@ -12,7 +12,7 @@ extern "C" {
 #define RAYMATH_STATIC_INLINE
 #endif
 #ifdef __GNUC__
-#pragma GCC diagnostic push  // These throw a warnings on visual studio, need to check if __GNUC__ is defined to use it.
+#pragma GCC diagnostic push // These throw a warnings on visual studio, need to check if __GNUC__ is defined to use it.
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 #include "raymath.h" // NOLINT
@@ -24,4 +24,4 @@ extern "C" {
 }
 #endif
 
-#endif  // RAYLIB_CPP_INCLUDE_RAYMATH_HPP_
+#endif // RAYLIB_CPP_INCLUDE_RAYMATH_HPP_

--- a/tests/raylib_cpp_test.cpp
+++ b/tests/raylib_cpp_test.cpp
@@ -1,9 +1,9 @@
+#include "raylib-assert.h"
+#include "raylib-cpp.hpp"
 #include <string>
 #include <vector>
-#include "raylib-cpp.hpp"
-#include "raylib-assert.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     TraceLog(LOG_INFO, "---------------------");
     TraceLog(LOG_INFO, "TEST: raylib-cpp test");
 
@@ -63,16 +63,13 @@ int main(int argc, char *argv[]) {
         Assert(image.IsReady());
 
         // Chaining
-        image.Crop(100, 100)
-            .Resize(50, 50);
+        image.Crop(100, 100).Resize(50, 50);
         AssertEqual(image.GetWidth(), 50);
         AssertEqual(image.GetHeight(), 50);
     }
 
     // Keyboard
-    {
-        AssertNot(raylib::Keyboard::IsKeyPressed(KEY_MINUS));
-    }
+    { AssertNot(raylib::Keyboard::IsKeyPressed(KEY_MINUS)); }
 
     // raylib::LoadDirectoryFiles()
     {
@@ -119,8 +116,7 @@ int main(int argc, char *argv[]) {
         bool passed = false;
         try {
             raylib::Texture texture("notfound.png");
-        }
-        catch (raylib::RaylibException& error) {
+        } catch (raylib::RaylibException& error) {
             error.TraceLog(LOG_INFO);
             passed = true;
         }


### PR DESCRIPTION
Hello,
I added my .clang-format mixed with [nuklear_console .clang-format](https://github.com/RobLoach/nuklear_console/blob/master/.clang-format) changes.

I also tried to close as possible to [raylib CONVENTIONS](https://github.com/raysan5/raylib/blob/master/CONVENTIONS.md):
The Name convention can be forced with .clang-tidy [readability-identifier-naming.*](https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html).

* ALWAYS initialize all defined variables.
* Do not use TABS, use 4 spaces instead.
* Avoid trailing spaces, please, avoid them
* ~~Control flow statements always are followed by a space~~ Use more common~~/"modern"~~ C++ style, see `BraceWrapping`
* Directories will be named using snake_case (see examples/), _C++ files are always PascalCase and with an .hpp-extension, avoid confusion with .h **C** files_
* _C raylib uses **right**-alignment pointers, my and RobLoach's .clang-format uses **left**-align pointers_

I try to make the style as close as possible to raylib AND modern C++, @RobLoach pls verify this style and use it from now on, make changes as you wishes ... after that I would recommend formatting the code before/after mergen an PR.
_(Use the formatted files as a "preview")_

---

For convince, I added a CMake command `format`, _I personally using [Format.cmake](https://github.com/TheLartians/Format.cmake)_, making a simple command does the job (I'm sure there are better solutions)
