### PR TITLE
Add missing const

### DIFF
--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -122,7 +122,7 @@ public:
         ::DrawLineBezier(startPos, endPos, thick, *this);
     }
 
-    void DrawLineStrip(::Vector2* points, int numPoints) const { ::DrawLineStrip(points, numPoints, *this); }
+    void DrawLineStrip(const ::Vector2* points, int numPoints) const { ::DrawLineStrip(points, numPoints, *this); }
 
     void DrawText(const char* text, int posX = 0, int posY = 0, int fontSize = 10.0f) const {
         ::DrawText(text, posX, posY, fontSize, *this);


### PR DESCRIPTION
Hi, I believe there is supposed to be a `const` here to match the C version.

```c
RLAPI void DrawLineStrip(const Vector2 *points, int pointCount, Color color);
```
https://github.com/raysan5/raylib/blob/master/src%2Fraylib.h#L1242