### PR TITLE
Adding boneMatrices to MeshUnmanaged to fix double free

### DIFF
--- a/include/MeshUnmanaged.hpp
+++ b/include/MeshUnmanaged.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "./BoundingBox.hpp"
+#include "./Matrix.hpp"
 #include "./Model.hpp"
 #include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
@@ -37,6 +38,7 @@ public:
         animNormals = nullptr;
         boneIds = nullptr;
         boneWeights = nullptr;
+        boneMatrices = nullptr;
         vaoId = 0;
         vboId = nullptr;
     }
@@ -242,6 +244,7 @@ protected:
         animNormals = mesh.animNormals;
         boneIds = mesh.boneIds;
         boneWeights = mesh.boneWeights;
+        boneMatrices = mesh.boneMatrices;
         vaoId = mesh.vaoId;
         vboId = mesh.vboId;
     }


### PR DESCRIPTION
I noticed a bug when trying out the models_first_person_maze example, that sometimes a double free occurs on UnloadMesh when destructor of MeshUnmanaged is called. The offending line is Line 1935 from rmodels.c from raylib, where
RL_FREE(mesh.boneMatrices) is called. To remedy this, I added a default assignment of nullptr to boneMatrices and explicit assignment throught the set method.