### PR TITLE
Security and clarity improvements

### DIFF
--- a/include/AudioDevice.hpp
+++ b/include/AudioDevice.hpp
@@ -18,7 +18,7 @@ public:
      *
      * @throws raylib::RaylibException Throws if the AudioDevice failed to initialize.
      */
-    AudioDevice(bool lateInit = false) {
+    explicit AudioDevice(bool lateInit = false) {
         if (!lateInit) {
             Init();
         }
@@ -34,7 +34,7 @@ public:
      *
      * @throws raylib::RaylibException Throws if the AudioDevice failed to initialize.
      */
-    void Init() {
+    static void Init()  {
         ::InitAudioDevice();
         if (!IsReady()) {
             throw RaylibException("Failed to initialize AudioDevice");
@@ -44,12 +44,12 @@ public:
     /**
      * Close the audio device and context.
      */
-    void Close() { ::CloseAudioDevice(); }
+    static void Close() { ::CloseAudioDevice(); }
 
     /**
      * Check if audio device has been initialized successfully.
      */
-    bool IsReady() const { return ::IsAudioDeviceReady(); }
+    static bool IsReady()  { return ::IsAudioDeviceReady(); }
 
     /**
      * Set master volume (listener).

--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -12,8 +12,9 @@ namespace raylib {
 class AudioStream : public ::AudioStream {
 public:
     AudioStream(const ::AudioStream& music)
-        : ::AudioStream(music)
-    { }
+        : ::AudioStream(music) {
+        // Nothing.
+    }
 
     AudioStream(
         rAudioBuffer* buffer = nullptr,

--- a/include/AudioStream.hpp
+++ b/include/AudioStream.hpp
@@ -11,7 +11,9 @@ namespace raylib {
  */
 class AudioStream : public ::AudioStream {
 public:
-    AudioStream(const ::AudioStream& music) { set(music); }
+    AudioStream(const ::AudioStream& music)
+        : ::AudioStream(music)
+    { }
 
     AudioStream(
         rAudioBuffer* buffer = nullptr,
@@ -34,7 +36,7 @@ public:
 
     AudioStream(const AudioStream&) = delete;
 
-    AudioStream(AudioStream&& other) {
+    AudioStream(AudioStream&& other) noexcept {
         set(other);
 
         other.buffer = nullptr;
@@ -96,7 +98,7 @@ public:
     /**
      * Check if any audio stream buffers requires refill
      */
-    bool IsProcessed() const { return ::IsAudioStreamProcessed(*this); }
+    [[nodiscard]] bool IsProcessed() const { return ::IsAudioStreamProcessed(*this); }
 
     /**
      * Play audio stream
@@ -125,7 +127,7 @@ public:
     /**
      * Check if audio stream is playing
      */
-    bool IsPlaying() const { return ::IsAudioStreamPlaying(*this); }
+    [[nodiscard]] bool IsPlaying() const { return ::IsAudioStreamPlaying(*this); }
 
     /**
      * Stop audio stream
@@ -182,7 +184,7 @@ public:
     /**
      * Retrieve whether or not the audio stream is ready.
      */
-    bool IsValid() const { return ::IsAudioStreamValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsAudioStreamValid(*this); }
 
     /**
      * Load audio stream (to stream raw audio pcm data)

--- a/include/AutomationEventList.hpp
+++ b/include/AutomationEventList.hpp
@@ -31,7 +31,7 @@ public:
 
     AutomationEventList(const AutomationEventList&) = delete;
 
-    AutomationEventList(AutomationEventList&& other) {
+    AutomationEventList(AutomationEventList&& other) noexcept {
         set(other);
 
         other.capacity = 0;

--- a/include/AutomationEventList.hpp
+++ b/include/AutomationEventList.hpp
@@ -4,7 +4,6 @@
 #include "./RaylibException.hpp"
 #include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
-#include <raylib.h>
 
 namespace raylib {
 /**

--- a/include/AutomationEventList.hpp
+++ b/include/AutomationEventList.hpp
@@ -4,6 +4,7 @@
 #include "./RaylibException.hpp"
 #include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
+#include <raylib.h>
 
 namespace raylib {
 /**
@@ -11,7 +12,10 @@ namespace raylib {
  */
 class AutomationEventList : public ::AutomationEventList {
 public:
-    AutomationEventList(const ::AutomationEventList& automationEventList) { set(automationEventList); }
+    AutomationEventList(const ::AutomationEventList& automationEventList)
+        : ::AutomationEventList(automationEventList) {
+        // Nothing.
+    }
 
     /**
      * Load an empty automation events list.

--- a/include/BoundingBox.hpp
+++ b/include/BoundingBox.hpp
@@ -41,17 +41,17 @@ public:
     /**
      * Detect collision between two boxes
      */
-    bool CheckCollision(const ::BoundingBox& box2) const { return CheckCollisionBoxes(*this, box2); }
+    [[nodiscard]] bool CheckCollision(const ::BoundingBox& box2) const { return CheckCollisionBoxes(*this, box2); }
 
     /**
      * Detect collision between box and sphere
      */
-    bool CheckCollision(::Vector3 center, float radius) const { return CheckCollisionBoxSphere(*this, center, radius); }
+    [[nodiscard]] bool CheckCollision(::Vector3 center, float radius) const { return CheckCollisionBoxSphere(*this, center, radius); }
 
     /**
      * Detect collision between ray and bounding box
      */
-    bool CheckCollision(const ::Ray& ray) const { return GetRayCollisionBox(ray, *this).hit; }
+    [[nodiscard]] bool CheckCollision(const ::Ray& ray) const { return GetRayCollisionBox(ray, *this).hit; }
 
     /**
      * Get collision information between ray and bounding box

--- a/include/Camera2D.hpp
+++ b/include/Camera2D.hpp
@@ -11,9 +11,12 @@ namespace raylib {
  */
 class Camera2D : public ::Camera2D {
 public:
-    Camera2D(const ::Camera2D& camera) { set(camera); }
+    Camera2D(const ::Camera2D& camera)
+        : ::Camera2D(camera) {
+        // Nothing.
+    }
 
-    Camera2D() {}
+    Camera2D() : ::Camera2D() {}
     Camera2D(::Vector2 offset, ::Vector2 target, float rotation = 0.0f, float zoom = 1.0f)
         : ::Camera2D{offset, target, rotation, zoom} {}
 
@@ -40,17 +43,17 @@ public:
     /**
      * Returns camera 2d transform matrix
      */
-    Matrix GetMatrix() const { return ::GetCameraMatrix2D(*this); }
+    [[nodiscard]] Matrix GetMatrix() const { return ::GetCameraMatrix2D(*this); }
 
     /**
      * Returns the world space position for a 2d camera screen space position
      */
-    Vector2 GetScreenToWorld(::Vector2 position) const { return ::GetScreenToWorld2D(position, *this); }
+    [[nodiscard]] Vector2 GetScreenToWorld(::Vector2 position) const { return ::GetScreenToWorld2D(position, *this); }
 
     /**
      * Returns the screen space position for a 2d world space position
      */
-    Vector2 GetWorldToScreen(::Vector2 position) const { return ::GetWorldToScreen2D(position, *this); }
+    [[nodiscard]] Vector2 GetWorldToScreen(::Vector2 position) const { return ::GetWorldToScreen2D(position, *this); }
 protected:
     void set(const ::Camera2D& camera) {
         offset = camera.offset;

--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -11,7 +11,7 @@ namespace raylib {
  */
 class Camera3D : public ::Camera3D {
 public:
-    Camera3D(const ::Camera3D& camera) { set(camera); }
+    Camera3D(const ::Camera3D& camera) : ::Camera3D(camera) { }
 
     /**
      * Create a new Camera3D.

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -36,43 +36,43 @@ public:
     /**
      * Get Color structure from hexadecimal value
      */
-    Color(unsigned int hexValue) { set(::GetColor(hexValue)); }
+    explicit Color(unsigned int hexValue) : ::Color(::GetColor(hexValue)) { }
 
-    Color(void* srcPtr, int format) { set(::GetPixelColor(srcPtr, format)); }
-
-    /**
-     * Returns hexadecimal value for a Color
-     */
-    int ToInt() const { return ::ColorToInt(*this); }
+    Color(void* srcPtr, int format) : ::Color(::GetPixelColor(srcPtr, format)) { }
 
     /**
      * Returns hexadecimal value for a Color
      */
-    operator int() const { return ::ColorToInt(*this); }
+    [[nodiscard]] int ToInt() const { return ::ColorToInt(*this); }
 
-    std::string ToString() const { return TextFormat("Color(%d, %d, %d, %d)", r, g, b, a); }
+    /**
+     * Returns hexadecimal value for a Color
+     */
+    explicit operator int() const { return ::ColorToInt(*this); }
 
-    operator std::string() const { return ToString(); }
+    [[nodiscard]] std::string ToString() const { return TextFormat("Color(%d, %d, %d, %d)", r, g, b, a); }
+
+    explicit operator std::string() const { return ToString(); }
 
     /**
      * Returns color with alpha applied, alpha goes from 0.0f to 1.0f
      */
-    Color Fade(float alpha) const { return ::Fade(*this, alpha); }
+    [[nodiscard]] Color Fade(float alpha) const { return ::Fade(*this, alpha); }
 
     /**
      * Returns Color normalized as float [0..1]
      */
-    Vector4 Normalize() const { return ::ColorNormalize(*this); }
+    [[nodiscard]] Vector4 Normalize() const { return ::ColorNormalize(*this); }
 
     /**
      * Returns Color from normalized values [0..1]
      */
-    Color(::Vector4 normalized) { set(::ColorFromNormalized(normalized)); }
+    explicit Color(::Vector4 normalized) : Color(::ColorFromNormalized(normalized)) { }
 
     /**
      * Returns HSV values for a Color
      */
-    Vector3 ToHSV() const { return ::ColorToHSV(*this); }
+    [[nodiscard]] Vector3 ToHSV() const { return ::ColorToHSV(*this); }
 
     GETTERSETTER(unsigned char, R, r)
     GETTERSETTER(unsigned char, G, g)
@@ -206,7 +206,7 @@ public:
     /**
      * Returns color with alpha applied, alpha goes from 0.0f to 1.0f
      */
-    Color Alpha(float alpha) const { return ::ColorAlpha(*this, alpha); }
+    [[nodiscard]] Color Alpha(float alpha) const { return ::ColorAlpha(*this, alpha); }
 
     Color Lerp(::Color color2, float factor) {
         return ::ColorLerp(*this, color2, factor);
@@ -215,7 +215,7 @@ public:
     /**
      * Returns src alpha-blended into dst color with tint
      */
-    Color AlphaBlend(::Color dst, ::Color tint) const { return ::ColorAlphaBlend(dst, *this, tint); }
+    [[nodiscard]] Color AlphaBlend(::Color dst, ::Color tint) const { return ::ColorAlphaBlend(dst, *this, tint); }
 
     static Color LightGray() { return LIGHTGRAY; }
     static Color Gray() { return GRAY; }

--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -84,7 +84,7 @@ public:
 
     Font(const Font&) = delete;
 
-    Font(Font&& other) {
+    Font(Font&& other) noexcept {
         set(other);
 
         other.baseSize = 0;

--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -28,9 +28,9 @@ public:
     /**
      * Retrieves the default Font.
      */
-    Font() { set(::GetFontDefault()); }
+    Font() : ::Font(::GetFontDefault()) { }
 
-    Font(const ::Font& font) { set(font); }
+    Font(const ::Font& font) : ::Font(font) { }
 
     /**
      * Loads a Font from the given file.
@@ -203,7 +203,7 @@ public:
     /**
      * Returns if the font is ready to be used.
      */
-    bool IsValid() const { return ::IsFontValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsFontValid(*this); }
 
     /**
      * Draw text using font and additional parameters.
@@ -286,33 +286,33 @@ public:
     /**
      * Measure string size for Font
      */
-    Vector2 MeasureText(const char* text, float fontSize, float spacing) const {
+    [[nodiscard]] Vector2 MeasureText(const char* text, float fontSize, float spacing) const {
         return ::MeasureTextEx(*this, text, fontSize, spacing);
     }
 
     /**
      * Measure string size for Font
      */
-    Vector2 MeasureText(const std::string& text, float fontSize, float spacing) const {
+    [[nodiscard]] Vector2 MeasureText(const std::string& text, float fontSize, float spacing) const {
         return ::MeasureTextEx(*this, text.c_str(), fontSize, spacing);
     }
 
     /**
      * Get index position for a unicode character on font
      */
-    int GetGlyphIndex(int character) const { return ::GetGlyphIndex(*this, character); }
+    [[nodiscard]] int GetGlyphIndex(int character) const { return ::GetGlyphIndex(*this, character); }
 
     /**
      * Create an image from text (custom sprite font)
      */
-    ::Image ImageText(const char* text, float fontSize, float spacing, ::Color tint) const {
+    [[nodiscard]] ::Image ImageText(const char* text, float fontSize, float spacing, ::Color tint) const {
         return ::ImageTextEx(*this, text, fontSize, spacing, tint);
     }
 
     /**
      * Create an image from text (custom sprite font)
      */
-    ::Image ImageText(const std::string& text, float fontSize, float spacing, ::Color tint) const {
+    [[nodiscard]] ::Image ImageText(const std::string& text, float fontSize, float spacing, ::Color tint) const {
         return ::ImageTextEx(*this, text.c_str(), fontSize, spacing, tint);
     }
 protected:

--- a/include/Gamepad.hpp
+++ b/include/Gamepad.hpp
@@ -18,21 +18,25 @@ public:
     GETTERSETTER(int, Number, number)
 
     Gamepad& operator=(const Gamepad& gamepad) {
-        set(gamepad);
+        if (this != &gamepad) {
+            set(static_cast<int>(gamepad));
+        }
         return *this;
     }
 
     Gamepad& operator=(int gamepadNumber) {
-        set(gamepadNumber);
+        if (this->number != gamepadNumber) {
+            set(gamepadNumber);
+        }
         return *this;
     }
 
-    operator int() const { return number; }
+    explicit operator int() const { return number; }
 
     /**
      * Detect if a gamepad is available
      */
-    bool IsAvailable() const { return ::IsGamepadAvailable(number); }
+    [[nodiscard]] bool IsAvailable() const { return ::IsGamepadAvailable(number); }
 
     /**
      * Detect if a gamepad is available
@@ -42,54 +46,54 @@ public:
     /**
      * Return gamepad internal name id
      */
-    std::string GetName() const { return ::GetGamepadName(number); }
+    [[nodiscard]] std::string GetName() const { return ::GetGamepadName(number); }
 
     /**
      * Return gamepad internal name id
      */
-    operator std::string() const { return GetName(); }
+    explicit operator std::string() const { return GetName(); }
 
     /**
      * Detect if a gamepad button has been pressed once
      */
-    bool IsButtonPressed(int button) const { return ::IsGamepadButtonPressed(number, button); }
+    [[nodiscard]] bool IsButtonPressed(int button) const { return ::IsGamepadButtonPressed(number, button); }
 
     /**
      * Detect if a gamepad button is being pressed
      */
-    bool IsButtonDown(int button) const { return ::IsGamepadButtonDown(number, button); }
+    [[nodiscard]] bool IsButtonDown(int button) const { return ::IsGamepadButtonDown(number, button); }
 
     /**
      * Detect if a gamepad button has been released once
      */
-    bool IsButtonReleased(int button) const { return ::IsGamepadButtonReleased(number, button); }
+    [[nodiscard]] bool IsButtonReleased(int button) const { return ::IsGamepadButtonReleased(number, button); }
 
     /**
      * Detect if a gamepad button is NOT being pressed
      */
-    bool IsButtonUp(int button) const { return ::IsGamepadButtonUp(number, button); }
+    [[nodiscard]] bool IsButtonUp(int button) const { return ::IsGamepadButtonUp(number, button); }
 
     /**
      * Get the last gamepad button pressed
      */
-    int GetButtonPressed() const { return ::GetGamepadButtonPressed(); }
+    static int GetButtonPressed() { return ::GetGamepadButtonPressed(); }
 
     /**
      * Return gamepad axis count for a gamepad
      */
-    int GetAxisCount() const { return ::GetGamepadAxisCount(number); }
+    [[nodiscard]] int GetAxisCount() const { return ::GetGamepadAxisCount(number); }
 
     /**
      * Return axis movement value for a gamepad axis
      */
-    float GetAxisMovement(int axis) const { return ::GetGamepadAxisMovement(number, axis); }
+    [[nodiscard]] float GetAxisMovement(int axis) const { return ::GetGamepadAxisMovement(number, axis); }
 
-    int SetMappings(const std::string& mappings) { return SetGamepadMappings(mappings.c_str()); }
+    static int SetMappings(const std::string& mappings) { return SetGamepadMappings(mappings.c_str()); }
 
     /**
      * Set gamepad vibration for both motors (duration in seconds)
      */
-    void SetVibration(float leftMotor, float rightMotor, float duration) {
+    void SetVibration(float leftMotor, float rightMotor, float duration) const {
         ::SetGamepadVibration(number, leftMotor, rightMotor, duration);
     }
 protected:

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -26,7 +26,7 @@ public:
         // Nothing.
     }
 
-    Image(const ::Image& image) { set(image); }
+    Image(const ::Image& image) : ::Image(image) { }
 
     /**
      * Load an image from the given file.
@@ -340,17 +340,17 @@ public:
     /**
      * Retrieve the width and height of the image.
      */
-    ::Vector2 GetSize() const { return {static_cast<float>(width), static_cast<float>(height)}; }
+    [[nodiscard]] ::Vector2 GetSize() const { return {static_cast<float>(width), static_cast<float>(height)}; }
 
     /**
      * Create an image duplicate (useful for transformations)
      */
-    ::Image Copy() const { return ::ImageCopy(*this); }
+    [[nodiscard]] ::Image Copy() const { return ::ImageCopy(*this); }
 
     /**
      * Create an image from another image piece
      */
-    ::Image FromImage(::Rectangle rec) const { return ::ImageFromImage(*this, rec); }
+    [[nodiscard]] ::Image FromImage(::Rectangle rec) const { return ::ImageFromImage(*this, rec); }
 
     /**
      * Convert image data to desired format
@@ -569,17 +569,17 @@ public:
      *
      * @param threshold Threshold is defined as a percentatge: 0.0f -> 1.0f
      */
-    Rectangle GetAlphaBorder(float threshold) const { return ::GetImageAlphaBorder(*this, threshold); }
+    [[nodiscard]] Rectangle GetAlphaBorder(float threshold) const { return ::GetImageAlphaBorder(*this, threshold); }
 
     /**
      * Get image pixel color at (x, y) position
      */
-    raylib::Color GetColor(int x = 0, int y = 0) const { return ::GetImageColor(*this, x, y); }
+    [[nodiscard]] raylib::Color GetColor(int x = 0, int y = 0) const { return ::GetImageColor(*this, x, y); }
 
     /**
      * Get image pixel color at vector position
      */
-    raylib::Color GetColor(::Vector2 position) const {
+    [[nodiscard]] raylib::Color GetColor(::Vector2 position) const {
         return ::GetImageColor(*this, static_cast<int>(position.x), static_cast<int>(position.y));
     }
 
@@ -692,7 +692,7 @@ public:
     /**
      * Load color data from image as a Color array (RGBA - 32bit)
      */
-    ::Color* LoadColors() const { return ::LoadImageColors(*this); }
+    [[nodiscard]] ::Color* LoadColors() const { return ::LoadImageColors(*this); }
 
     /**
      * Load colors palette from image as a Color array (RGBA - 32bit)
@@ -714,14 +714,14 @@ public:
     /**
      * Load texture from image data.
      */
-    ::Texture2D LoadTexture() const { return ::LoadTextureFromImage(*this); }
+    [[nodiscard]] ::Texture2D LoadTexture() const { return ::LoadTextureFromImage(*this); }
 
     /**
      * Loads a texture from the image data.
      *
      * @see LoadTexture()
      */
-    operator ::Texture2D() { return LoadTexture(); }
+    operator ::Texture2D() const { return LoadTexture(); }
 
     /**
      * Get pixel data size in bytes for certain format
@@ -735,14 +735,14 @@ public:
      *
      * @return The pixel data size of the image.
      */
-    int GetPixelDataSize() const { return ::GetPixelDataSize(width, height, format); }
+    [[nodiscard]] int GetPixelDataSize() const { return ::GetPixelDataSize(width, height, format); }
 
     /**
      * Retrieve whether or not the Image has been loaded.
      *
      * @return True or false depending on whether the Image has been loaded.
      */
-    bool IsValid() const { return ::IsImageValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsImageValid(*this); }
 
     /**
      * Create an image from a selected channel of another image (GRAYSCALE)

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -90,7 +90,7 @@ public:
 
     Image(const Image& other) { set(other.Copy()); }
 
-    Image(Image&& other) {
+    Image(Image&& other) noexcept {
         set(other);
 
         other.data = nullptr;

--- a/include/Keyboard.hpp
+++ b/include/Keyboard.hpp
@@ -1,13 +1,13 @@
 #ifndef RAYLIB_CPP_INCLUDE_KEYBOARD_HPP_
 #define RAYLIB_CPP_INCLUDE_KEYBOARD_HPP_
 
+#include "Functions.hpp"
 #include "./raylib.hpp"
 
-namespace raylib {
 /**
  * Input-related functions: keyboard
  */
-namespace Keyboard {
+namespace raylib::Keyboard {
 /**
  * Detect if a key has been pressed once
  */
@@ -57,8 +57,8 @@ namespace Keyboard {
 [[maybe_unused]] RLCPPAPI inline int GetCharPressed() {
     return ::GetCharPressed();
 }
-} // namespace Keyboard
-} // namespace raylib
+} // namespace raylib::Keyboard
+
 namespace RKeyboard = raylib::Keyboard;
 
 #endif // RAYLIB_CPP_INCLUDE_KEYBOARD_HPP_

--- a/include/Keyboard.hpp
+++ b/include/Keyboard.hpp
@@ -1,7 +1,7 @@
 #ifndef RAYLIB_CPP_INCLUDE_KEYBOARD_HPP_
 #define RAYLIB_CPP_INCLUDE_KEYBOARD_HPP_
 
-#include "Functions.hpp"
+#include "./Functions.hpp"
 #include "./raylib.hpp"
 
 /**

--- a/include/Keyboard.hpp
+++ b/include/Keyboard.hpp
@@ -4,10 +4,11 @@
 #include "./Functions.hpp"
 #include "./raylib.hpp"
 
+namespace raylib {
 /**
  * Input-related functions: keyboard
  */
-namespace raylib::Keyboard {
+namespace Keyboard {
 /**
  * Detect if a key has been pressed once
  */
@@ -57,7 +58,8 @@ namespace raylib::Keyboard {
 [[maybe_unused]] RLCPPAPI inline int GetCharPressed() {
     return ::GetCharPressed();
 }
-} // namespace raylib::Keyboard
+} // namespace Keyboard
+} // namespace raylib
 
 namespace RKeyboard = raylib::Keyboard;
 

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -13,12 +13,12 @@ namespace raylib {
  */
 class Material : public ::Material {
 public:
-    Material(const ::Material& material) { set(material); }
+    Material(const ::Material& material) : ::Material(material) {  }
 
     /**
      * Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
      */
-    Material() { set(LoadMaterialDefault()); }
+    Material() : ::Material(LoadMaterialDefault()) { }
 
     Material(const Material&) = delete;
 
@@ -104,7 +104,7 @@ public:
     /**
      * Check if material is ready
      */
-    bool IsValid() const { return ::IsMaterialValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsMaterialValid(*this); }
 protected:
     void set(const ::Material& material) {
         shader = material.shader;

--- a/include/Material.hpp
+++ b/include/Material.hpp
@@ -22,7 +22,7 @@ public:
 
     Material(const Material&) = delete;
 
-    Material(Material&& other) {
+    Material(Material&& other) noexcept {
         set(other);
 
         other.maps = nullptr;

--- a/include/Matrix.hpp
+++ b/include/Matrix.hpp
@@ -16,23 +16,7 @@ namespace raylib {
 class Matrix : public ::Matrix {
 public:
     Matrix(const ::Matrix& mat)
-        : ::Matrix{
-              mat.m0,
-              mat.m4,
-              mat.m8,
-              mat.m12,
-              mat.m1,
-              mat.m5,
-              mat.m9,
-              mat.m13,
-              mat.m2,
-              mat.m6,
-              mat.m10,
-              mat.m14,
-              mat.m3,
-              mat.m7,
-              mat.m11,
-              mat.m15} {
+        : ::Matrix(mat) {
         // Nothing.
     }
 
@@ -75,12 +59,16 @@ public:
     GETTERSETTER(float, M15, m15)
 
     Matrix& operator=(const ::Matrix& matrix) {
-        set(matrix);
+        if (this != &matrix) {
+            set(matrix);
+        }
         return *this;
     }
 
     Matrix& operator=(const Matrix& matrix) {
-        set(matrix);
+        if (this != &matrix) {
+            set(matrix);
+        }
         return *this;
     }
 
@@ -97,14 +85,14 @@ public:
     /**
      * Returns the trace of the matrix (sum of the values along the diagonal)
      */
-    float Trace() const { return ::MatrixTrace(*this); }
+    [[nodiscard]] float Trace() const { return ::MatrixTrace(*this); }
 
     /**
      * Transposes provided matrix
      */
-    Matrix Transpose() const { return ::MatrixTranspose(*this); }
+    [[nodiscard]] Matrix Transpose() const { return ::MatrixTranspose(*this); }
 
-    Matrix Invert() const { return ::MatrixInvert(*this); }
+    [[nodiscard]] Matrix Invert() const { return ::MatrixInvert(*this); }
 
     static Matrix Identity() { return ::MatrixIdentity(); }
 
@@ -130,7 +118,7 @@ public:
 
     static Matrix Scale(float x, float y, float z) { return ::MatrixScale(x, y, z); }
 
-    Matrix Multiply(const ::Matrix& right) const { return ::MatrixMultiply(*this, right); }
+    [[nodiscard]] Matrix Multiply(const ::Matrix& right) const { return ::MatrixMultiply(*this, right); }
 
     Matrix operator*(const ::Matrix& matrix) { return ::MatrixMultiply(*this, matrix); }
 
@@ -148,9 +136,9 @@ public:
 
     static Matrix LookAt(Vector3 eye, Vector3 target, Vector3 up) { return ::MatrixLookAt(eye, target, up); }
 
-    float16 ToFloatV() const { return ::MatrixToFloatV(*this); }
+    [[nodiscard]] float16 ToFloatV() const { return ::MatrixToFloatV(*this); }
 
-    operator float16() { return ToFloatV(); }
+    operator float16() const { return ToFloatV(); }
 
     /**
      * Set shader uniform value (matrix 4x4)

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -35,7 +35,7 @@ public:
     /**
      * Move constructor.
      */
-    Mesh(Mesh&& other) {
+    Mesh(Mesh&& other) noexcept {
         set(other);
 
         other.vertexCount = 0;

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-#include "./BoundingBox.hpp"
 #include "./MeshUnmanaged.hpp"
 #include "./Model.hpp"
 #include "./raylib-cpp-utils.hpp"

--- a/include/MeshUnmanaged.hpp
+++ b/include/MeshUnmanaged.hpp
@@ -8,7 +8,6 @@
 #include "./Matrix.hpp"
 #include "./Model.hpp"
 #include "./raylib-cpp-utils.hpp"
-#include "./raylib.hpp"
 
 namespace raylib {
 

--- a/include/MeshUnmanaged.hpp
+++ b/include/MeshUnmanaged.hpp
@@ -200,12 +200,12 @@ public:
     /**
      * Compute mesh bounding box limits
      */
-    raylib::BoundingBox BoundingBox() const { return ::GetMeshBoundingBox(*this); }
+    [[nodiscard]] raylib::BoundingBox BoundingBox() const { return ::GetMeshBoundingBox(*this); }
 
     /**
      * Compute mesh bounding box limits
      */
-    operator raylib::BoundingBox() { return BoundingBox(); }
+    operator raylib::BoundingBox() const { return BoundingBox(); }
 
     /**
      * Compute mesh tangents
@@ -218,7 +218,7 @@ public:
     /**
      * Load model from generated mesh
      */
-    raylib::Model LoadModelFrom() const { return ::LoadModelFromMesh(*this); }
+    [[nodiscard]] raylib::Model LoadModelFrom() const { return ::LoadModelFromMesh(*this); }
 
     /**
      * Load model from generated mesh

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -50,7 +50,7 @@ public:
 
     Model(const Model&) = delete;
 
-    Model(Model&& other) {
+    Model(Model&& other) noexcept {
         set(other);
 
         other.meshCount = 0;

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -21,7 +21,7 @@ public:
     /*
      * Copy a model from another model.
      */
-    Model(const ::Model& model) { set(model); }
+    Model(const ::Model& model) : ::Model(model) { }
 
     /*
      * Load a model from a file.
@@ -138,7 +138,7 @@ public:
     /**
      * Check model animation skeleton match
      */
-    bool IsModelAnimationValid(const ::ModelAnimation& anim) const { return ::IsModelAnimationValid(*this, anim); }
+    [[nodiscard]] bool IsModelAnimationValid(const ::ModelAnimation& anim) const { return ::IsModelAnimationValid(*this, anim); }
 
     /**
      * Draw a model (with texture if set)
@@ -195,17 +195,17 @@ public:
     /**
      * Compute model bounding box limits (considers all meshes)
      */
-    BoundingBox GetBoundingBox() const { return ::GetModelBoundingBox(*this); }
+    [[nodiscard]] BoundingBox GetBoundingBox() const { return ::GetModelBoundingBox(*this); }
 
     /**
      * Compute model bounding box limits (considers all meshes)
      */
-    operator BoundingBox() const { return ::GetModelBoundingBox(*this); }
+    explicit operator BoundingBox() const { return ::GetModelBoundingBox(*this); }
 
     /**
      * Determines whether or not the Model has data in it.
      */
-    bool IsValid() const { return ::IsModelValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsModelValid(*this); }
 
     /**
      * Loads a Model from the given file.

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -18,7 +18,7 @@ public:
 
     ModelAnimation(const ModelAnimation&) = delete;
 
-    ModelAnimation(ModelAnimation&& other) {
+    ModelAnimation(ModelAnimation&& other) noexcept {
         set(other);
 
         other.boneCount = 0;

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -94,7 +94,7 @@ public:
     /**
      * Check model animation skeleton match
      */
-    bool IsValid(const ::Model& model) const { return ::IsModelAnimationValid(model, *this); }
+    [[nodiscard]] bool IsValid(const ::Model& model) const { return ::IsModelAnimationValid(model, *this); }
 protected:
     void set(const ::ModelAnimation& model) {
         boneCount = model.boneCount;

--- a/include/Mouse.hpp
+++ b/include/Mouse.hpp
@@ -1,6 +1,7 @@
 #ifndef RAYLIB_CPP_INCLUDE_MOUSE_HPP_
 #define RAYLIB_CPP_INCLUDE_MOUSE_HPP_
 
+#include "./Functions.hpp"
 #include "./Vector2.hpp"
 #include "./raylib.hpp"
 

--- a/include/Music.hpp
+++ b/include/Music.hpp
@@ -21,7 +21,7 @@ public:
         void* ctxData = nullptr)
         : ::Music{stream, frameCount, looping, ctxType, ctxData} {}
 
-    Music(const ::Music& music) { set(music); }
+    Music(const ::Music& music) : ::Music(music) { }
 
     /**
      * Load music stream from file
@@ -140,7 +140,7 @@ public:
     /**
      * Check if music is playing
      */
-    bool IsPlaying() const { return ::IsMusicStreamPlaying(*this); }
+    [[nodiscard]] bool IsPlaying() const { return ::IsMusicStreamPlaying(*this); }
 
     /**
      * Set volume for music

--- a/include/Music.hpp
+++ b/include/Music.hpp
@@ -39,7 +39,7 @@ public:
 
     Music(const Music&) = delete;
 
-    Music(Music&& other) {
+    Music(Music&& other) noexcept {
         set(other);
 
         other.stream = {};
@@ -169,12 +169,12 @@ public:
     /**
      * Get music time length (in seconds)
      */
-    float GetTimeLength() const { return ::GetMusicTimeLength(*this); }
+    [[nodiscard]] float GetTimeLength() const { return ::GetMusicTimeLength(*this); }
 
     /**
      * Get current music time played (in seconds)
      */
-    float GetTimePlayed() const { return ::GetMusicTimePlayed(*this); }
+    [[nodiscard]] float GetTimePlayed() const { return ::GetMusicTimePlayed(*this); }
 
     /**
      * Load music stream from file

--- a/include/RayCollision.hpp
+++ b/include/RayCollision.hpp
@@ -3,7 +3,6 @@
 
 #include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
-#include <raylib.h>
 
 namespace raylib {
 /**

--- a/include/RayCollision.hpp
+++ b/include/RayCollision.hpp
@@ -3,6 +3,7 @@
 
 #include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
+#include <raylib.h>
 
 namespace raylib {
 /**
@@ -10,7 +11,7 @@ namespace raylib {
  */
 class RayCollision : public ::RayCollision {
 public:
-    RayCollision(const ::RayCollision& ray) { set(ray); }
+    RayCollision(const ::RayCollision& ray) : ::RayCollision(ray) { }
 
     RayCollision(bool hit, float distance, ::Vector3 point, ::Vector3 normal)
         : ::RayCollision{hit, distance, point, normal} {
@@ -20,34 +21,41 @@ public:
     /**
      * Get collision info between ray and bounding box
      */
-    RayCollision(const ::Ray& ray, const ::BoundingBox& box) { set(::GetRayCollisionBox(ray, box)); }
+    RayCollision(const ::Ray& ray, const ::BoundingBox& box)
+        : ::RayCollision(::GetRayCollisionBox(ray, box)) {
+        // Nothing.
+    }
 
     /**
      * Get collision info between ray and mesh
      */
-    RayCollision(const ::Ray& ray, const ::Mesh& mesh, const ::Matrix& transform) {
-        set(::GetRayCollisionMesh(ray, mesh, transform));
+    RayCollision(const ::Ray& ray, const ::Mesh& mesh, const ::Matrix& transform)
+        : ::RayCollision(::GetRayCollisionMesh(ray, mesh, transform)) {
+        // Nothing.
     }
 
     /**
      * Get collision info between ray and quad
      */
-    RayCollision(const ::Ray& ray, ::Vector3 p1, ::Vector3 p2, ::Vector3 p3, ::Vector3 p4) {
-        set(::GetRayCollisionQuad(ray, p1, p2, p3, p4));
+    RayCollision(const ::Ray& ray, ::Vector3 p1, ::Vector3 p2, ::Vector3 p3, ::Vector3 p4)
+        : ::RayCollision(::GetRayCollisionQuad(ray, p1, p2, p3, p4)) {
+        // Nothing.
     }
 
     /**
      * Get collision info between ray and sphere
      */
-    RayCollision(const ::Ray& ray, ::Vector3 center, float radius) {
-        set(::GetRayCollisionSphere(ray, center, radius));
+    RayCollision(const ::Ray& ray, ::Vector3 center, float radius)
+        : ::RayCollision(::GetRayCollisionSphere(ray, center, radius)) {
+        // Nothing.
     }
 
     /**
      * Get collision info between ray and triangle
      */
-    RayCollision(const ::Ray& ray, ::Vector3 p1, ::Vector3 p2, ::Vector3 p3) {
-        set(::GetRayCollisionTriangle(ray, p1, p2, p3));
+    RayCollision(const ::Ray& ray, ::Vector3 p1, ::Vector3 p2, ::Vector3 p3)
+        : ::RayCollision(::GetRayCollisionTriangle(ray, p1, p2, p3)) {
+        // Nothing.
     }
 
     RayCollision& operator=(const ::RayCollision& ray) {

--- a/include/RaylibException.hpp
+++ b/include/RaylibException.hpp
@@ -17,7 +17,7 @@ public:
      *
      * @param message The message to provide for the exception.
      */
-    RaylibException(std::string message) throw() : std::runtime_error(message) {
+    explicit RaylibException(const std::string& message) noexcept : std::runtime_error(message) {
         // Nothing
     }
 

--- a/include/Rectangle.hpp
+++ b/include/Rectangle.hpp
@@ -35,7 +35,7 @@ public:
 
     ::Vector4 ToVector4() { return {x, y, width, height}; }
 
-    operator ::Vector4() const { return {x, y, width, height}; }
+    explicit operator ::Vector4() const { return {x, y, width, height}; }
 
     /**
      * Draw a color-filled rectangle
@@ -96,26 +96,26 @@ public:
     /**
      * Check collision between two rectangles
      */
-    bool CheckCollision(::Rectangle rec2) const { return ::CheckCollisionRecs(*this, rec2); }
+    [[nodiscard]] bool CheckCollision(::Rectangle rec2) const { return ::CheckCollisionRecs(*this, rec2); }
 
     /**
      * Get collision rectangle for two rectangles collision
      */
-    ::Rectangle GetCollision(::Rectangle rec2) const { return ::GetCollisionRec(*this, rec2); }
+    [[nodiscard]] ::Rectangle GetCollision(::Rectangle rec2) const { return ::GetCollisionRec(*this, rec2); }
 
     /**
      * Check if point is inside rectangle
      */
-    bool CheckCollision(::Vector2 point) const { return ::CheckCollisionPointRec(point, *this); }
+    [[nodiscard]] bool CheckCollision(::Vector2 point) const { return ::CheckCollisionPointRec(point, *this); }
 
     /**
      * Check collision between circle and rectangle
      */
-    bool CheckCollision(::Vector2 center, float radius) const {
+    [[nodiscard]] bool CheckCollision(::Vector2 center, float radius) const {
         return ::CheckCollisionCircleRec(center, radius, *this);
     }
 
-    Vector2 GetSize() const { return {width, height}; }
+    [[nodiscard]] Vector2 GetSize() const { return {width, height}; }
 
     Rectangle& SetSize(float newWidth, float newHeight) {
         width = newWidth;
@@ -130,7 +130,7 @@ public:
         return *this;
     }
 
-    Vector2 GetPosition() const { return {x, y}; }
+    [[nodiscard]] Vector2 GetPosition() const { return {x, y}; }
 
     Rectangle& SetPosition(float newX, float newY) {
         x = newX;

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -1,11 +1,8 @@
 #ifndef RAYLIB_CPP_INCLUDE_RENDERTEXTURE_HPP_
 #define RAYLIB_CPP_INCLUDE_RENDERTEXTURE_HPP_
 
-#include "./RaylibException.hpp"
 #include "./TextureUnmanaged.hpp"
 #include "./raylib-cpp-utils.hpp"
-#include "./raylib.hpp"
-#include <raylib.h>
 
 namespace raylib {
 /**

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -5,6 +5,7 @@
 #include "./TextureUnmanaged.hpp"
 #include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
+#include <raylib.h>
 
 namespace raylib {
 /**
@@ -15,9 +16,15 @@ public:
     /**
      * Default constructor to build an empty RenderTexture.
      */
-    RenderTexture() { id = 0; }
+    RenderTexture()
+        : ::RenderTexture{ .id = 0 } {
+        // Nothing.
+    }
 
-    RenderTexture(const ::RenderTexture& renderTexture) { set(renderTexture); }
+    RenderTexture(const ::RenderTexture& renderTexture)
+        : ::RenderTexture(renderTexture) {
+        // Nothing.
+    }
 
     RenderTexture(unsigned int id, const ::Texture& texture, const ::Texture& depth)
         : ::RenderTexture{id, texture, depth} {}
@@ -25,11 +32,15 @@ public:
     /**
      * Load texture for rendering (framebuffer)
      */
-    RenderTexture(int width, int height) { set(::LoadRenderTexture(width, height)); }
+    RenderTexture(int width, int height)
+        : ::RenderTexture(::LoadRenderTexture(width, height)) {
+        // Nothing.
+    }
 
     RenderTexture(const RenderTexture&) = delete;
 
-    RenderTexture(RenderTexture&& other) {
+    RenderTexture(RenderTexture&& other) noexcept
+    {
         set(other);
 
         other.id = 0;
@@ -103,7 +114,7 @@ public:
     /**
      * Retrieves whether or not the render texture is ready.
      */
-    bool IsValid() const { return ::IsRenderTextureValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsRenderTextureValid(*this); }
 protected:
     void set(const ::RenderTexture& renderTexture) {
         id = renderTexture.id;

--- a/include/RenderTexture.hpp
+++ b/include/RenderTexture.hpp
@@ -13,10 +13,7 @@ public:
     /**
      * Default constructor to build an empty RenderTexture.
      */
-    RenderTexture()
-        : ::RenderTexture{ .id = 0 } {
-        // Nothing.
-    }
+    RenderTexture() = default;
 
     RenderTexture(const ::RenderTexture& renderTexture)
         : ::RenderTexture(renderTexture) {

--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -18,7 +18,7 @@ public:
 
     Shader(const Shader&) = delete;
 
-    Shader(Shader&& other) {
+    Shader(Shader&& other) noexcept {
         set(other);
 
         other.id = 0;

--- a/include/ShaderUnmanaged.hpp
+++ b/include/ShaderUnmanaged.hpp
@@ -1,12 +1,11 @@
 #ifndef RAYLIB_CPP_INCLUDE_UNMANAGEDSHADER_HPP_
 #define RAYLIB_CPP_INCLUDE_UNMANAGEDSHADER_HPP_
 
-#include <rlgl.h>
-#include <string>
-
-#include "Texture.hpp"
 #include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
+
+#include <rlgl.h>
+#include <string>
 
 namespace raylib {
 
@@ -17,7 +16,7 @@ class ShaderUnmanaged : public ::Shader {
 public:
     ShaderUnmanaged() : ::Shader{rlGetShaderIdDefault(), rlGetShaderLocsDefault()} {}
 
-    ShaderUnmanaged(const ::Shader& shader) { set(shader); }
+    ShaderUnmanaged(const ::Shader& shader) : ::Shader(shader) { }
 
     ShaderUnmanaged(unsigned int id, int* locs = nullptr) : ::Shader{id, locs} {}
 
@@ -79,14 +78,14 @@ public:
      *
      * @see GetShaderLocation()
      */
-    int GetLocation(const std::string& uniformName) const { return ::GetShaderLocation(*this, uniformName.c_str()); }
+    [[nodiscard]] int GetLocation(const std::string& uniformName) const { return ::GetShaderLocation(*this, uniformName.c_str()); }
 
     /**
      * Get shader attribute location
      *
      * @see GetShaderLocationAttrib()
      */
-    int GetLocationAttrib(const std::string& attribName) const {
+    [[nodiscard]] int GetLocationAttrib(const std::string& attribName) const {
         return ::GetShaderLocationAttrib(*this, attribName.c_str());
     }
 
@@ -133,7 +132,7 @@ public:
     /**
      * Retrieves whether or not the shader is ready.
      */
-    bool IsValid() const { return ::IsShaderValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsShaderValid(*this); }
 protected:
     void set(const ::Shader& shader) {
         id = shader.id;

--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -30,7 +30,7 @@ public:
         // Nothing.
     }
 
-    Sound(Sound&& other) {
+    Sound(Sound&& other) noexcept {
         set(other);
 
         other.stream = {nullptr, nullptr, 0, 0, 0};

--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -131,7 +131,7 @@ public:
     /**
      * Check if a sound is currently playing
      */
-    bool IsPlaying() const { return ::IsSoundPlaying(*this); }
+    [[nodiscard]] bool IsPlaying() const { return ::IsSoundPlaying(*this); }
 
     /**
      * Set volume for a sound (1.0 is max level)
@@ -186,7 +186,7 @@ public:
      *
      * @return True or false depending on whether the Sound buffer is loaded.
      */
-    bool IsValid() const { return ::IsSoundValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsSoundValid(*this); }
 protected:
     void set(const ::Sound& sound) {
         frameCount = sound.frameCount;

--- a/include/Text.hpp
+++ b/include/Text.hpp
@@ -84,7 +84,7 @@ public:
         // Nothing.
     }
 
-    GETTERSETTER(std::string, Text, text)
+    GETTERSETTER(const std::string&, Text, text)
     GETTERSETTER(float, FontSize, fontSize)
     GETTERSETTER(::Font, Font, font)
     GETTERSETTER(::Color, Color, color)
@@ -120,12 +120,12 @@ public:
     /**
      * Measure string width for default font
      */
-    int Measure() const { return ::MeasureText(text.c_str(), static_cast<int>(fontSize)); }
+    [[nodiscard]] int Measure() const { return ::MeasureText(text.c_str(), static_cast<int>(fontSize)); }
 
     /**
      * Measure string size for Font
      */
-    Vector2 MeasureEx() const { return ::MeasureTextEx(font, text.c_str(), fontSize, spacing); }
+    [[nodiscard]] Vector2 MeasureEx() const { return ::MeasureTextEx(font, text.c_str(), fontSize, spacing); }
 
     Text& operator=(const Text& other) {
         if (this == &other) {

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -28,7 +28,7 @@ public:
     /**
      * Move constructor.
      */
-    Texture(Texture&& other) {
+    Texture(Texture&& other)  noexcept {
         set(other);
 
         other.id = 0;

--- a/include/TextureUnmanaged.hpp
+++ b/include/TextureUnmanaged.hpp
@@ -89,7 +89,7 @@ public:
     /**
      * Retrieve the width and height of the texture.
      */
-    Vector2 GetSize() const { return {static_cast<float>(width), static_cast<float>(height)}; }
+    [[nodiscard]] Vector2 GetSize() const { return {static_cast<float>(width), static_cast<float>(height)}; }
 
     /**
      * Load texture from image data
@@ -151,7 +151,7 @@ public:
     /**
      * Get pixel data from GPU texture and return an Image
      */
-    ::Image GetData() const { return ::LoadImageFromTexture(*this); }
+    [[nodiscard]] ::Image GetData() const { return ::LoadImageFromTexture(*this); }
 
     /**
      * Get pixel data from GPU texture and return an Image
@@ -319,7 +319,7 @@ public:
      *
      * @return True or false depending on whether the Texture has data.
      */
-    bool IsValid() const { return IsTextureValid(*this); }
+    [[nodiscard]] bool IsValid() const { return IsTextureValid(*this); }
 protected:
     void set(const ::Texture& texture) {
         id = texture.id;

--- a/include/Touch.hpp
+++ b/include/Touch.hpp
@@ -1,6 +1,7 @@
 #ifndef RAYLIB_CPP_INCLUDE_TOUCH_HPP_
 #define RAYLIB_CPP_INCLUDE_TOUCH_HPP_
 
+#include "./Functions.hpp"
 #include "./raylib.hpp"
 
 namespace raylib {

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -44,7 +44,7 @@ public:
      */
     bool operator!=(const ::Vector2& other) const { return !(*this == other); }
 
-    std::string ToString() const { return TextFormat("Vector2(%f, %f)", x, y); }
+    [[nodiscard]] std::string ToString() const { return TextFormat("Vector2(%f, %f)", x, y); }
 
     operator std::string() const { return ToString(); }
 
@@ -71,7 +71,7 @@ public:
     /**
      * Subtract two vectors (v1 - v2)
      */
-    Vector2 Subtract(const ::Vector2& vector2) const { return Vector2Subtract(*this, vector2); }
+    [[nodiscard]] Vector2 Subtract(const ::Vector2& vector2) const { return Vector2Subtract(*this, vector2); }
 
     /**
      * Subtract two vectors (v1 - v2)
@@ -90,7 +90,7 @@ public:
     /**
      * Negate vector
      */
-    Vector2 Negate() const { return Vector2Negate(*this); }
+    [[nodiscard]] Vector2 Negate() const { return Vector2Negate(*this); }
 
     /**
      * Negate vector
@@ -100,7 +100,7 @@ public:
     /**
      * Multiply vector by vector
      */
-    Vector2 Multiply(const ::Vector2& vector2) const { return Vector2Multiply(*this, vector2); }
+    [[nodiscard]] Vector2 Multiply(const ::Vector2& vector2) const { return Vector2Multiply(*this, vector2); }
 
     /**
      * Multiply vector by vector
@@ -119,7 +119,7 @@ public:
     /**
      * Scale vector (multiply by value)
      */
-    Vector2 Scale(const float scale) const { return Vector2Scale(*this, scale); }
+    [[nodiscard]] Vector2 Scale(const float scale) const { return Vector2Scale(*this, scale); }
 
     /**
      * Scale vector (multiply by value)
@@ -138,7 +138,7 @@ public:
     /**
      * Divide vector by vector
      */
-    Vector2 Divide(const ::Vector2& vector2) const { return Vector2Divide(*this, vector2); }
+    [[nodiscard]] Vector2 Divide(const ::Vector2& vector2) const { return Vector2Divide(*this, vector2); }
 
 
     /**
@@ -158,7 +158,7 @@ public:
     /**
      * Divide vector by value
      */
-    Vector2 Divide(const float div) const { return ::Vector2{x / div, y / div}; }
+    [[nodiscard]] Vector2 Divide(const float div) const { return ::Vector2{x / div, y / div}; }
 
     /**
      * Divide vector by value
@@ -178,84 +178,84 @@ public:
     /**
      * Normalize provided vector
      */
-    Vector2 Normalize() const { return Vector2Normalize(*this); }
+    [[nodiscard]] Vector2 Normalize() const { return Vector2Normalize(*this); }
 
     /**
      * Transforms a Vector2 by a given Matrix
      */
-    Vector2 Transform(::Matrix mat) const { return ::Vector2Transform(*this, mat); }
+    [[nodiscard]] Vector2 Transform(::Matrix mat) const { return ::Vector2Transform(*this, mat); }
 
     /**
      * Calculate linear interpolation between two vectors
      */
-    Vector2 Lerp(const ::Vector2& vector2, float amount) const { return Vector2Lerp(*this, vector2, amount); }
+    [[nodiscard]] Vector2 Lerp(const ::Vector2& vector2, float amount) const { return Vector2Lerp(*this, vector2, amount); }
 
     /**
      * Calculate reflected vector to normal
      */
-    Vector2 Reflect(const ::Vector2& normal) const { return Vector2Reflect(*this, normal); }
+    [[nodiscard]] Vector2 Reflect(const ::Vector2& normal) const { return Vector2Reflect(*this, normal); }
 
     /**
      * Rotate Vector by float in radians
      */
-    Vector2 Rotate(float angle) const { return Vector2Rotate(*this, angle); }
+    [[nodiscard]] Vector2 Rotate(float angle) const { return Vector2Rotate(*this, angle); }
 
     /**
      * Move Vector towards target
      */
-    Vector2 MoveTowards(const ::Vector2& target, float maxDistance) const {
+    [[nodiscard]] Vector2 MoveTowards(const ::Vector2& target, float maxDistance) const {
         return Vector2MoveTowards(*this, target, maxDistance);
     }
 
     /**
      * Invert the given vector
      */
-    Vector2 Invert() const { return ::Vector2Invert(*this); }
+    [[nodiscard]] Vector2 Invert() const { return ::Vector2Invert(*this); }
 
     /**
      * Clamp the components of the vector between
      */
-    Vector2 Clamp(::Vector2 min, ::Vector2 max) const { return ::Vector2Clamp(*this, min, max); }
+    [[nodiscard]] Vector2 Clamp(::Vector2 min, ::Vector2 max) const { return ::Vector2Clamp(*this, min, max); }
 
     /**
      * // Clamp the magnitude of the vector between two min and max values
      */
-    Vector2 Clamp(float min, float max) const { return ::Vector2ClampValue(*this, min, max); }
+    [[nodiscard]] Vector2 Clamp(float min, float max) const { return ::Vector2ClampValue(*this, min, max); }
 
     /**
      * Check whether two given vectors are almost equal
      */
-    int Equals(::Vector2 q) const { return ::Vector2Equals(*this, q); }
+    [[nodiscard]] int Equals(::Vector2 q) const { return ::Vector2Equals(*this, q); }
 
     /**
      * Calculate vector length
      */
-    float Length() const { return Vector2Length(*this); }
+    [[nodiscard]] float Length() const { return Vector2Length(*this); }
 
     /**
      * Calculate vector square length
      */
-    float LengthSqr() const { return Vector2LengthSqr(*this); }
+    [[nodiscard]] float LengthSqr() const { return Vector2LengthSqr(*this); }
 
     /**
      * Calculate two vectors dot product
      */
-    float DotProduct(const ::Vector2& vector2) const { return Vector2DotProduct(*this, vector2); }
+    [[nodiscard]] float DotProduct(const ::Vector2& vector2) const { return Vector2DotProduct(*this, vector2); }
 
     /**
      * Calculate distance between two vectors
      */
-    float Distance(const ::Vector2& vector2) const { return Vector2Distance(*this, vector2); }
+    [[nodiscard]] float Distance(const ::Vector2& vector2) const { return Vector2Distance(*this, vector2); }
 
     /**
      * Calculate square distance between two vectors
      */
-    float DistanceSqr(::Vector2 v2) const { return ::Vector2DistanceSqr(*this, v2); }
+    [[nodiscard]] float DistanceSqr(::Vector2 v2) const { return ::Vector2DistanceSqr(*this, v2); }
 
     /**
      * Calculate angle from two vectors in X-axis
      */
-    float Angle(const ::Vector2& vector2) const { return Vector2Angle(*this, vector2); }
+    [[nodiscard]] float Angle(const ::Vector2& vector2) const { return Vector2Angle(*this, vector2); }
 
     /**
      * Vector with components value 0.0f
@@ -294,33 +294,33 @@ public:
     /**
      * Check collision between two circles
      */
-    bool CheckCollisionCircle(float radius1, ::Vector2 center2, float radius2) const {
+    [[nodiscard]] bool CheckCollisionCircle(float radius1, ::Vector2 center2, float radius2) const {
         return ::CheckCollisionCircles(*this, radius1, center2, radius2);
     }
 
     /**
      * Check collision between circle and rectangle
      */
-    bool CheckCollisionCircle(float radius, ::Rectangle rec) const {
+    [[nodiscard]] bool CheckCollisionCircle(float radius, ::Rectangle rec) const {
         return ::CheckCollisionCircleRec(*this, radius, rec);
     }
 
     /**
      * Check if point is inside rectangle
      */
-    bool CheckCollision(::Rectangle rec) const { return ::CheckCollisionPointRec(*this, rec); }
+    [[nodiscard]] bool CheckCollision(::Rectangle rec) const { return ::CheckCollisionPointRec(*this, rec); }
 
     /**
      * Check if point is inside circle
      */
-    bool CheckCollision(::Vector2 center, float radius) const {
+    [[nodiscard]] bool CheckCollision(::Vector2 center, float radius) const {
         return ::CheckCollisionPointCircle(*this, center, radius);
     }
 
     /**
      * Check if point is inside a triangle
      */
-    bool CheckCollision(::Vector2 p1, ::Vector2 p2, ::Vector2 p3) const {
+    [[nodiscard]] bool CheckCollision(::Vector2 p1, ::Vector2 p2, ::Vector2 p3) const {
         return ::CheckCollisionPointTriangle(*this, p1, p2, p3);
     }
 
@@ -335,7 +335,7 @@ public:
     /**
      * Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
      */
-    bool CheckCollisionPointLine(::Vector2 p1, ::Vector2 p2, int threshold = 1) const {
+    [[nodiscard]] bool CheckCollisionPointLine(::Vector2 p1, ::Vector2 p2, int threshold = 1) const {
         return ::CheckCollisionPointLine(*this, p1, p2, threshold);
     }
 protected:

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -39,7 +39,7 @@ public:
 
     bool operator!=(const ::Vector3& other) const { return !(*this == other); }
 
-    std::string ToString() const { return TextFormat("Vector3(%f, %f, %f)", x, y, z); }
+    [[nodiscard]] std::string ToString() const { return TextFormat("Vector3(%f, %f, %f)", x, y, z); }
 
     operator std::string() const { return ToString(); }
 
@@ -47,7 +47,7 @@ public:
     /**
      * Add two vectors
      */
-    Vector3 Add(const ::Vector3& vector3) const { return Vector3Add(*this, vector3); }
+    [[nodiscard]] Vector3 Add(const ::Vector3& vector3) const { return Vector3Add(*this, vector3); }
 
     /**
      * Add two vectors
@@ -63,7 +63,7 @@ public:
     /**
      * Subtract two vectors.
      */
-    Vector3 Subtract(const ::Vector3& vector3) const { return Vector3Subtract(*this, vector3); }
+    [[nodiscard]] Vector3 Subtract(const ::Vector3& vector3) const { return Vector3Subtract(*this, vector3); }
 
     /**
      * Subtract two vectors.
@@ -79,7 +79,7 @@ public:
     /**
      * Negate provided vector (invert direction)
      */
-    Vector3 Negate() const { return Vector3Negate(*this); }
+    [[nodiscard]] Vector3 Negate() const { return Vector3Negate(*this); }
 
     /**
      * Negate provided vector (invert direction)
@@ -89,7 +89,7 @@ public:
     /**
      * Multiply vector by vector
      */
-    Vector3 Multiply(const ::Vector3& vector3) const { return Vector3Multiply(*this, vector3); }
+    [[nodiscard]] Vector3 Multiply(const ::Vector3& vector3) const { return Vector3Multiply(*this, vector3); }
 
     /**
      * Multiply vector by vector
@@ -108,7 +108,7 @@ public:
     /**
      * Multiply vector by scalar
      */
-    Vector3 Scale(const float scaler) const { return Vector3Scale(*this, scaler); }
+    [[nodiscard]] Vector3 Scale(const float scaler) const { return Vector3Scale(*this, scaler); }
 
     /**
      * Multiply vector by scalar
@@ -127,7 +127,7 @@ public:
     /**
      * Divide vector by vector
      */
-    Vector3 Divide(const ::Vector3& vector3) const { return Vector3Divide(*this, vector3); }
+    [[nodiscard]] Vector3 Divide(const ::Vector3& vector3) const { return Vector3Divide(*this, vector3); }
 
     /**
      * Divide vector by vector
@@ -148,7 +148,7 @@ public:
     /**
      * Divide a vector by a value.
      */
-    Vector3 Divide(const float div) const { return ::Vector3{x / div, y / div, z / div}; }
+    [[nodiscard]] Vector3 Divide(const float div) const { return ::Vector3{x / div, y / div, z / div}; }
 
     /**
      * Divide a vector by a value.
@@ -169,44 +169,44 @@ public:
     /**
      * Calculate vector length
      */
-    float Length() const { return Vector3Length(*this); }
+    [[nodiscard]] float Length() const { return Vector3Length(*this); }
 
     /**
      * Calculate vector square length
      */
-    float LengthSqr() const { return Vector3LengthSqr(*this); }
+    [[nodiscard]] float LengthSqr() const { return Vector3LengthSqr(*this); }
 
-    Vector3 Normalize() const { return Vector3Normalize(*this); }
+    [[nodiscard]] Vector3 Normalize() const { return Vector3Normalize(*this); }
 
-    float DotProduct(const ::Vector3& vector3) const { return Vector3DotProduct(*this, vector3); }
+    [[nodiscard]] float DotProduct(const ::Vector3& vector3) const { return Vector3DotProduct(*this, vector3); }
 
-    float Distance(const ::Vector3& vector3) const { return Vector3Distance(*this, vector3); }
+    [[nodiscard]] float Distance(const ::Vector3& vector3) const { return Vector3Distance(*this, vector3); }
 
-    Vector3 Lerp(const ::Vector3& vector3, const float amount) const { return Vector3Lerp(*this, vector3, amount); }
+    [[nodiscard]] Vector3 Lerp(const ::Vector3& vector3, const float amount) const { return Vector3Lerp(*this, vector3, amount); }
 
-    Vector3 CrossProduct(const ::Vector3& vector3) const { return Vector3CrossProduct(*this, vector3); }
+    [[nodiscard]] Vector3 CrossProduct(const ::Vector3& vector3) const { return Vector3CrossProduct(*this, vector3); }
 
-    Vector3 Perpendicular() const { return Vector3Perpendicular(*this); }
+    [[nodiscard]] Vector3 Perpendicular() const { return Vector3Perpendicular(*this); }
 
-    Vector3 Project(const ::Vector3& vector3) const { return Vector3Project(*this, vector3); }
+    [[nodiscard]] Vector3 Project(const ::Vector3& vector3) const { return Vector3Project(*this, vector3); }
 
-    Vector3 Reject(const ::Vector3& vector3) const { return Vector3Reject(*this, vector3); }
+    [[nodiscard]] Vector3 Reject(const ::Vector3& vector3) const { return Vector3Reject(*this, vector3); }
 
     void OrthoNormalize(::Vector3* vector3) { Vector3OrthoNormalize(this, vector3); }
 
-    Vector3 Transform(const ::Matrix& matrix) const { return Vector3Transform(*this, matrix); }
+    [[nodiscard]] Vector3 Transform(const ::Matrix& matrix) const { return Vector3Transform(*this, matrix); }
 
-    Vector3 RotateByQuaternion(const ::Quaternion& quaternion) const {
+    [[nodiscard]] Vector3 RotateByQuaternion(const ::Quaternion& quaternion) const {
         return Vector3RotateByQuaternion(*this, quaternion);
     }
 
-    Vector3 Reflect(const ::Vector3& normal) const { return Vector3Reflect(*this, normal); }
+    [[nodiscard]] Vector3 Reflect(const ::Vector3& normal) const { return Vector3Reflect(*this, normal); }
 
-    Vector3 Min(const ::Vector3& vector3) const { return Vector3Min(*this, vector3); }
+    [[nodiscard]] Vector3 Min(const ::Vector3& vector3) const { return Vector3Min(*this, vector3); }
 
-    Vector3 Max(const ::Vector3& vector3) const { return Vector3Max(*this, vector3); }
+    [[nodiscard]] Vector3 Max(const ::Vector3& vector3) const { return Vector3Max(*this, vector3); }
 
-    Vector3 Barycenter(const ::Vector3& a, const ::Vector3& b, const ::Vector3& c) const {
+    [[nodiscard]] Vector3 Barycenter(const ::Vector3& a, const ::Vector3& b, const ::Vector3& c) const {
         return Vector3Barycenter(*this, a, b, c);
     }
 
@@ -258,7 +258,7 @@ public:
     /**
      * Detect collision between two spheres
      */
-    bool CheckCollision(float radius1, const ::Vector3& center2, float radius2) const {
+    [[nodiscard]] bool CheckCollision(float radius1, const ::Vector3& center2, float radius2) const {
         return CheckCollisionSpheres(*this, radius1, center2, radius2);
     }
 protected:

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -45,47 +45,47 @@ public:
 
     bool operator!=(const ::Vector4& other) const { return !(*this == other); }
 
-    ::Rectangle ToRectangle() const { return {x, y, z, w}; }
+    [[nodiscard]] ::Rectangle ToRectangle() const { return {x, y, z, w}; }
 
     operator ::Rectangle() const { return {x, y, z, w}; }
 
-    std::string ToString() const { return TextFormat("Vector4(%f, %f, %f, %f)", x, y, z, w); }
+    [[nodiscard]] std::string ToString() const { return TextFormat("Vector4(%f, %f, %f, %f)", x, y, z, w); }
 
     operator std::string() const { return ToString(); }
 
 #ifndef RAYLIB_CPP_NO_MATH
-    Vector4 Multiply(const ::Vector4& vector4) const { return QuaternionMultiply(*this, vector4); }
+    [[nodiscard]] Vector4 Multiply(const ::Vector4& vector4) const { return QuaternionMultiply(*this, vector4); }
 
     Vector4 operator*(const ::Vector4& vector4) const { return QuaternionMultiply(*this, vector4); }
 
-    Vector4 Lerp(const ::Vector4& vector4, float amount) const { return QuaternionLerp(*this, vector4, amount); }
+    [[nodiscard]] Vector4 Lerp(const ::Vector4& vector4, float amount) const { return QuaternionLerp(*this, vector4, amount); }
 
-    Vector4 Nlerp(const ::Vector4& vector4, float amount) const { return QuaternionNlerp(*this, vector4, amount); }
+    [[nodiscard]] Vector4 Nlerp(const ::Vector4& vector4, float amount) const { return QuaternionNlerp(*this, vector4, amount); }
 
-    Vector4 Slerp(const ::Vector4& vector4, float amount) const { return QuaternionSlerp(*this, vector4, amount); }
+    [[nodiscard]] Vector4 Slerp(const ::Vector4& vector4, float amount) const { return QuaternionSlerp(*this, vector4, amount); }
 
-    Matrix ToMatrix() const { return QuaternionToMatrix(*this); }
+    [[nodiscard]] Matrix ToMatrix() const { return QuaternionToMatrix(*this); }
 
-    float Length() const { return QuaternionLength(*this); }
+    [[nodiscard]] float Length() const { return QuaternionLength(*this); }
 
-    Vector4 Normalize() const { return QuaternionNormalize(*this); }
+    [[nodiscard]] Vector4 Normalize() const { return QuaternionNormalize(*this); }
 
-    Vector4 Invert() const { return QuaternionInvert(*this); }
+    [[nodiscard]] Vector4 Invert() const { return QuaternionInvert(*this); }
 
     void ToAxisAngle(::Vector3* outAxis, float* outAngle) const { QuaternionToAxisAngle(*this, outAxis, outAngle); }
 
     /**
      * Get the rotation angle and axis for a given quaternion
      */
-    std::pair<Vector3, float> ToAxisAngle() const {
+    [[nodiscard]] std::pair<Vector3, float> ToAxisAngle() const {
         Vector3 outAxis;
         float outAngle;
         QuaternionToAxisAngle(*this, &outAxis, &outAngle);
 
-        return std::pair<Vector3, float>(outAxis, outAngle);
+        return { outAxis, outAngle };
     }
 
-    Vector4 Transform(const ::Matrix& matrix) const { return ::QuaternionTransform(*this, matrix); }
+    [[nodiscard]] Vector4 Transform(const ::Matrix& matrix) const { return ::QuaternionTransform(*this, matrix); }
 
     static Vector4 Identity() { return ::QuaternionIdentity(); }
 
@@ -107,10 +107,10 @@ public:
         return ::QuaternionFromEuler(vector3.x, vector3.y, vector3.z);
     }
 
-    Vector3 ToEuler() const { return ::QuaternionToEuler(*this); }
+    [[nodiscard]] Vector3 ToEuler() const { return ::QuaternionToEuler(*this); }
 #endif
 
-    Color ColorFromNormalized() const { return ::ColorFromNormalized(*this); }
+    [[nodiscard]] Color ColorFromNormalized() const { return ::ColorFromNormalized(*this); }
 
     operator Color() const { return ColorFromNormalized(); }
 protected:

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -43,7 +43,7 @@ public:
 
     Wave(const Wave& other) { set(other.Copy()); }
 
-    Wave(Wave&& other) {
+    Wave(Wave&& other) noexcept {
         set(other);
 
         other.frameCount = 0;

--- a/include/Wave.hpp
+++ b/include/Wave.hpp
@@ -13,7 +13,7 @@ namespace raylib {
  */
 class Wave : public ::Wave {
 public:
-    Wave(const ::Wave& wave) { set(wave); }
+    Wave(const ::Wave& wave) : ::Wave(wave) { }
 
     Wave(
         unsigned int frameCount = 0,
@@ -100,7 +100,7 @@ public:
     /**
      * Copy a wave to a new wave
      */
-    ::Wave Copy() const { return ::WaveCopy(*this); }
+    [[nodiscard]] ::Wave Copy() const { return ::WaveCopy(*this); }
 
     /**
      * Crop a wave to defined samples range
@@ -194,7 +194,7 @@ public:
      *
      * @return True or false depending on whether the wave data has been loaded.
      */
-    bool IsValid() const { return ::IsWaveValid(*this); }
+    [[nodiscard]] bool IsValid() const { return ::IsWaveValid(*this); }
 protected:
     void set(const ::Wave& wave) {
         frameCount = wave.frameCount;

--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -18,9 +18,7 @@ public:
      *
      * @see Init()
      */
-    Window() {
-        // Nothing.
-    }
+    Window() = default;
 
     /**
      * Initialize window and OpenGL context.
@@ -57,7 +55,7 @@ public:
      *
      * @throws raylib::RaylibException Thrown if the window failed to initiate.
      */
-    void Init(int width = 800, int height = 450, const std::string& title = "raylib", unsigned int flags = 0) {
+    static void Init(int width = 800, int height = 450, const std::string& title = "raylib", unsigned int flags = 0) {
         if (flags != 0) {
             ::SetConfigFlags(flags);
         }
@@ -70,17 +68,17 @@ public:
     /**
      * Check if KEY_ESCAPE pressed or Close icon pressed
      */
-    bool ShouldClose() const { return ::WindowShouldClose(); }
+    static bool ShouldClose()  { return ::WindowShouldClose(); }
 
     /**
      * Set a custom key to exit program (default is ESC)
      */
-    void SetExitKey(int key) { ::SetExitKey(key); }
+    static void SetExitKey(int key) { ::SetExitKey(key); }
 
     /**
      * Close window and unload OpenGL context
      */
-    void Close() {
+    static void Close() {
         if (::IsWindowReady()) {
             ::CloseWindow();
         }
@@ -89,42 +87,42 @@ public:
     /**
      * Check if cursor is on the current screen
      */
-    bool IsCursorOnScreen() const { return ::IsCursorOnScreen(); }
+    static bool IsCursorOnScreen()  { return ::IsCursorOnScreen(); }
 
     /**
      * Check if window is currently fullscreen
      */
-    bool IsFullscreen() const { return ::IsWindowFullscreen(); }
+    static bool IsFullscreen()  { return ::IsWindowFullscreen(); }
 
     /**
      * Check if window is currently hidden
      */
-    bool IsHidden() const { return ::IsWindowHidden(); }
+    static bool IsHidden()  { return ::IsWindowHidden(); }
 
     /**
      * Check if window is currently minimized
      */
-    bool IsMinimized() const { return ::IsWindowMinimized(); }
+    static bool IsMinimized()  { return ::IsWindowMinimized(); }
 
     /**
      * Check if window is currently minimized
      */
-    bool IsMaximized() const { return ::IsWindowMaximized(); }
+    static bool IsMaximized()  { return ::IsWindowMaximized(); }
 
     /**
      * Check if window is currently focused
      */
-    bool IsFocused() const { return ::IsWindowFocused(); }
+    static bool IsFocused()  { return ::IsWindowFocused(); }
 
     /**
      * Check if window has been resized last frame
      */
-    bool IsResized() const { return ::IsWindowResized(); }
+    static bool IsResized()  { return ::IsWindowResized(); }
 
     /**
      * Check if one specific window flag is enabled
      */
-    bool IsState(unsigned int flag) const { return ::IsWindowState(flag); }
+    static bool IsState(unsigned int flag)  { return ::IsWindowState(flag); }
 
     /**
      * Set window configuration state using flags
@@ -303,12 +301,12 @@ public:
     /**
      * Get the screen's width and height.
      */
-    Vector2 GetSize() const { return {static_cast<float>(GetWidth()), static_cast<float>(GetHeight())}; }
+    static Vector2 GetSize() { return {static_cast<float>(GetWidth()), static_cast<float>(GetHeight())}; }
 
     /**
      * Get native window handle
      */
-    void* GetHandle() const { return ::GetWindowHandle(); }
+    static void* GetHandle() { return ::GetWindowHandle(); }
 
     /**
      * Setup canvas (framebuffer) to start drawing
@@ -329,42 +327,42 @@ public:
     /**
      * Get current screen width
      */
-    int GetWidth() const { return ::GetScreenWidth(); }
+    static int GetWidth() { return ::GetScreenWidth(); }
 
     /**
      * Get current screen height
      */
-    int GetHeight() const { return ::GetScreenHeight(); }
+    static int GetHeight() { return ::GetScreenHeight(); }
 
     /**
      * Get current render width (it considers HiDPI)
      */
-    int GetRenderWidth() const { return ::GetRenderWidth(); }
+    static int GetRenderWidth() { return ::GetRenderWidth(); }
 
     /**
      * Get current render height (it considers HiDPI)
      */
-    int GetRenderHeight() const { return ::GetRenderHeight(); }
+    static int GetRenderHeight() { return ::GetRenderHeight(); }
 
     /**
      * Get window position XY on monitor
      */
-    Vector2 GetPosition() const { return ::GetWindowPosition(); }
+    static Vector2 GetPosition() { return ::GetWindowPosition(); }
 
     /**
      * Get window scale DPI factor
      */
-    Vector2 GetScaleDPI() const { return ::GetWindowScaleDPI(); }
+    static Vector2 GetScaleDPI() { return ::GetWindowScaleDPI(); }
 
     /**
      * Set clipboard text content
      */
-    void SetClipboardText(const std::string& text) { ::SetClipboardText(text.c_str()); }
+    static void SetClipboardText(const std::string& text) { ::SetClipboardText(text.c_str()); }
 
     /**
      * Get clipboard text content
      */
-    const std::string GetClipboardText() { return ::GetClipboardText(); }
+    static std::string GetClipboardText() { return ::GetClipboardText(); }
 
     /**
      * Set target FPS (maximum)
@@ -377,22 +375,22 @@ public:
     /**
      * Returns current FPS
      */
-    int GetFPS() const { return ::GetFPS(); }
+    static int GetFPS()  { return ::GetFPS(); }
 
     /**
      * Draw current FPS
      */
-    void DrawFPS(int posX = 10, int posY = 10) const { ::DrawFPS(posX, posY); }
+    static void DrawFPS(int posX = 10, int posY = 10)  { ::DrawFPS(posX, posY); }
 
     /**
      * Returns time in seconds for last frame drawn
      */
-    float GetFrameTime() const { return ::GetFrameTime(); }
+    static float GetFrameTime()  { return ::GetFrameTime(); }
 
     /**
      * Returns elapsed time in seconds since InitWindow()
      */
-    double GetTime() const { return ::GetTime(); }
+    static double GetTime()  { return ::GetTime(); }
 
     /**
      * Check if window has been initialized successfully
@@ -406,7 +404,7 @@ public:
      *
      * @see ::SetConfigFlags
      */
-    void SetConfigFlags(unsigned int flags) { ::SetConfigFlags(flags); }
+    static void SetConfigFlags(unsigned int flags) { ::SetConfigFlags(flags); }
 };
 } // namespace raylib
 


### PR DESCRIPTION
I mainly added `static` to member functions where applicable, as well as `noexcept` to move constructors.

I also added the `explicit` keyword where preferable, while avoiding it in cases where the intent was clearly to facilitate logical conversions.

Additionally, I added the `[[nodiscard]]` attribute where appropriate, given that I also noticed the use of `[[maybe_unused]]` and thus assumed that the addition would be acceptable. This can always be removed if needed.

I also adjusted some inclusion issues that could prevent compilation depending on the order in which the headers were included, without directly including `raylib-cpp.hpp`.

There is also the addition of a few missing `const` qualifiers.

Finally, I made a few adjustments to constructors, avoiding initialization in the constructor body via `set()` where possible.