### PR TITLE
Different Default-Colours Wrapping

### DIFF
--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -212,33 +212,6 @@ public:
      * Returns src alpha-blended into dst color with tint
      */
     [[nodiscard]] Color AlphaBlend(::Color dst, ::Color tint) const { return ::ColorAlphaBlend(dst, *this, tint); }
-
-    static constexpr Color LightGray = LIGHTGRAY;
-    static constexpr Color Gray = GRAY;
-    static constexpr Color DarkGray = DARKGRAY;
-    static constexpr Color Yellow = YELLOW;
-    static constexpr Color Gold = GOLD;
-    static constexpr Color Orange = ORANGE;
-    static constexpr Color Pink = PINK;
-    static constexpr Color Red = RED;
-    static constexpr Color Maroon = MAROON;
-    static constexpr Color Green = GREEN;
-    static constexpr Color Lime = LIME;
-    static constexpr Color DarkGreen = DARKGREEN;
-    static constexpr Color SkyBlue = SKYBLUE;
-    static constexpr Color Blue = BLUE;
-    static constexpr Color DarkBlue = DARKBLUE;
-    static constexpr Color Purple = PURPLE;
-    static constexpr Color Violet = VIOLET;
-    static constexpr Color DarkPurple = DARKPURPLE;
-    static constexpr Color Beige = BEIGE;
-    static constexpr Color Brown = BROWN;
-    static constexpr Color DarkBrown = DARKBROWN;
-    static constexpr Color White = WHITE;
-    static constexpr Color Black = BLACK;
-    static constexpr Color Blank = BLANK;
-    static constexpr Color Magenta = MAGENTA;
-    static constexpr Color RayWhite = RAYWHITE;
 protected:
     void set(const ::Color& color) {
         r = color.r;
@@ -247,6 +220,33 @@ protected:
         a = color.a;
     }
 };
+
+    constexpr Color LightGray = LIGHTGRAY;
+    constexpr Color Gray = GRAY;
+    constexpr Color DarkGray = DARKGRAY;
+    constexpr Color Yellow = YELLOW;
+    constexpr Color Gold = GOLD;
+    constexpr Color Orange = ORANGE;
+    constexpr Color Pink = PINK;
+    constexpr Color Red = RED;
+    constexpr Color Maroon = MAROON;
+    constexpr Color Green = GREEN;
+    constexpr Color Lime = LIME;
+    constexpr Color DarkGreen = DARKGREEN;
+    constexpr Color SkyBlue = SKYBLUE;
+    constexpr Color Blue = BLUE;
+    constexpr Color DarkBlue = DARKBLUE;
+    constexpr Color Purple = PURPLE;
+    constexpr Color Violet = VIOLET;
+    constexpr Color DarkPurple = DARKPURPLE;
+    constexpr Color Beige = BEIGE;
+    constexpr Color Brown = BROWN;
+    constexpr Color DarkBrown = DARKBROWN;
+    constexpr Color White = WHITE;
+    constexpr Color Black = BLACK;
+    constexpr Color Blank = BLANK;
+    constexpr Color Magenta = MAGENTA;
+    constexpr Color RayWhite = RAYWHITE;
 
 } // namespace raylib
 

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -213,64 +213,37 @@ public:
      */
     [[nodiscard]] Color AlphaBlend(::Color dst, ::Color tint) const { return ::ColorAlphaBlend(dst, *this, tint); }
 
-    /* I think it deprecated
-    static Color LightGray() { return LIGHTGRAY; }
-    static Color Gray() { return GRAY; }
-    static Color DarkGray() { return DARKGRAY; }
-    static Color Yellow() { return YELLOW; }
-    static Color Gold() { return GOLD; }
-    static Color Orange() { return ORANGE; }
-    static Color Pink() { return PINK; }
-    static Color Red() { return RED; }
-    static Color Maroon() { return MAROON; }
-    static Color Green() { return GREEN; }
-    static Color Lime() { return LIME; }
-    static Color DarkGreen() { return DARKGREEN; }
-    static Color SkyBlue() { return SKYBLUE; }
-    static Color Blue() { return BLUE; }
-    static Color DarkBlue() { return DARKBLUE; }
-    static Color Purple() { return PURPLE; }
-    static Color Violet() { return VIOLET; }
-    static Color DarkPurple() { return DARKPURPLE; }
-    static Color Beige() { return BEIGE; }
-    static Color Brown() { return BROWN; }
-    static Color DarkBrown() { return DARKBROWN; }
-    static Color White() { return WHITE; }
-    static Color Black() { return BLACK; }
-    static Color Blank() { return BLANK; }
-    static Color Magenta() { return MAGENTA; }
-    static Color RayWhite() { return RAYWHITE; }
-    */
-
     /**
-     * As an alternative to a function calling convention
+     * The default color preprocessors wrapped as constexpr
+     * Use:
+     *     raylib::Color::RayWhite
      */
-    constexpr Color LightGray = LIGHTGRAY;
-    constexpr Color Gray = GRAY;
-    constexpr Color DarkGray = DARKGRAY;
-    constexpr Color Yellow = YELLOW;
-    constexpr Color Gold = GOLD;
-    constexpr Color Orange = ORANGE;
-    constexpr Color Pink = PINK;
-    constexpr Color Red = RED;
-    constexpr Color Maroon = MAROON;
-    constexpr Color Green = GREEN;
-    constexpr Color Lime = LIME;
-    constexpr Color DarkGreen = DARKGREEN;
-    constexpr Color SkyBlue = SKYBLUE;
-    constexpr Color Blue = BLUE;
-    constexpr Color DarkBlue = DARKBLUE;
-    constexpr Color Purple = PURPLE;
-    constexpr Color Violet = VIOLET;
-    constexpr Color DarkPurple = DARKPURPLE;
-    constexpr Color Beige = BEIGE;
-    constexpr Color Brown = BROWN;
-    constexpr Color DarkBrown = DARKBROWN;
-    constexpr Color White = WHITE;
-    constexpr Color Black = BLACK;
-    constexpr Color Blank = BLANK;
-    constexpr Color Magenta = MAGENTA;
-    constexpr Color RayWhite = RAYWHITE;
+    static constexpr Color LightGray = LIGHTGRAY;
+    static constexpr Color Gray = GRAY;
+    static constexpr Color DarkGray = DARKGRAY;
+    static constexpr Color Yellow = YELLOW;
+    static constexpr Color Gold = GOLD;
+    static constexpr Color Orange = ORANGE;
+    static constexpr Color Pink = PINK;
+    static constexpr Color Red = RED;
+    static constexpr Color Maroon = MAROON;
+    static constexpr Color Green = GREEN;
+    static constexpr Color Lime = LIME;
+    static constexpr Color DarkGreen = DARKGREEN;
+    static constexpr Color SkyBlue = SKYBLUE;
+    static constexpr Color Blue = BLUE;
+    static constexpr Color DarkBlue = DARKBLUE;
+    static constexpr Color Purple = PURPLE;
+    static constexpr Color Violet = VIOLET;
+    static constexpr Color DarkPurple = DARKPURPLE;
+    static constexpr Color Beige = BEIGE;
+    static constexpr Color Brown = BROWN;
+    static constexpr Color DarkBrown = DARKBROWN;
+    static constexpr Color White = WHITE;
+    static constexpr Color Black = BLACK;
+    static constexpr Color Blank = BLANK;
+    static constexpr Color Magenta = MAGENTA;
+    static constexpr Color RayWhite = RAYWHITE;
 protected:
     void set(const ::Color& color) {
         r = color.r;

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -13,15 +13,15 @@ namespace raylib {
  */
 class Color : public ::Color {
 public:
-    Color(const ::Color& color) : ::Color{color.r, color.g, color.b, color.a} {}
+    Color(const ::Color& color) : ::Color{color.r, color.g, color.b, color.a} { }
 
     Color(unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha = 255)
-        : ::Color{red, green, blue, alpha} {};
+        : ::Color{red, green, blue, alpha} { };
 
     /**
      * Black.
      */
-    Color() : ::Color{0, 0, 0, 255} {};
+    Color() : ::Color{0, 0, 0, 255} { };
 
     /**
      * Returns a Color from HSV values
@@ -36,9 +36,9 @@ public:
     /**
      * Get Color structure from hexadecimal value
      */
-    explicit Color(unsigned int hexValue) : ::Color(::GetColor(hexValue)) {}
+    explicit Color(unsigned int hexValue) : ::Color(::GetColor(hexValue)) { }
 
-    Color(void* srcPtr, int format) : ::Color(::GetPixelColor(srcPtr, format)) {}
+    Color(void* srcPtr, int format) : ::Color(::GetPixelColor(srcPtr, format)) { }
 
     /**
      * Returns hexadecimal value for a Color
@@ -67,7 +67,7 @@ public:
     /**
      * Returns Color from normalized values [0..1]
      */
-    explicit Color(::Vector4 normalized) : Color(::ColorFromNormalized(normalized)) {}
+    explicit Color(::Vector4 normalized) : Color(::ColorFromNormalized(normalized)) { }
 
     /**
      * Returns HSV values for a Color

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -213,11 +213,6 @@ public:
      */
     [[nodiscard]] Color AlphaBlend(::Color dst, ::Color tint) const { return ::ColorAlphaBlend(dst, *this, tint); }
 
-    /**
-     * The default color preprocessors wrapped as constexpr
-     * Use:
-     *     raylib::Color::RayWhite
-     */
     static constexpr Color LightGray = LIGHTGRAY;
     static constexpr Color Gray = GRAY;
     static constexpr Color DarkGray = DARKGRAY;

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -36,9 +36,9 @@ public:
     /**
      * Get Color structure from hexadecimal value
      */
-    explicit Color(unsigned int hexValue) : ::Color(::GetColor(hexValue)) { }
+    explicit Color(unsigned int hexValue) : ::Color(::GetColor(hexValue)) {}
 
-    Color(void* srcPtr, int format) : ::Color(::GetPixelColor(srcPtr, format)) { }
+    Color(void* srcPtr, int format) : ::Color(::GetPixelColor(srcPtr, format)) {}
 
     /**
      * Returns hexadecimal value for a Color
@@ -67,7 +67,7 @@ public:
     /**
      * Returns Color from normalized values [0..1]
      */
-    explicit Color(::Vector4 normalized) : Color(::ColorFromNormalized(normalized)) { }
+    explicit Color(::Vector4 normalized) : Color(::ColorFromNormalized(normalized)) {}
 
     /**
      * Returns HSV values for a Color
@@ -181,9 +181,7 @@ public:
 
     void DrawRectangleLines(::Rectangle rec, float lineThick) const { ::DrawRectangleLinesEx(rec, lineThick, *this); }
 
-    bool IsEqual(::Color color) {
-        return ::ColorIsEqual(*this, color);
-    }
+    bool IsEqual(::Color color) { return ::ColorIsEqual(*this, color); }
 
     bool operator==(const ::Color& other) const { return ::ColorIsEqual(*this, other); }
     bool operator!=(const ::Color& other) const { return !::ColorIsEqual(*this, other); }
@@ -208,15 +206,14 @@ public:
      */
     [[nodiscard]] Color Alpha(float alpha) const { return ::ColorAlpha(*this, alpha); }
 
-    Color Lerp(::Color color2, float factor) {
-        return ::ColorLerp(*this, color2, factor);
-    }
+    Color Lerp(::Color color2, float factor) { return ::ColorLerp(*this, color2, factor); }
 
     /**
      * Returns src alpha-blended into dst color with tint
      */
     [[nodiscard]] Color AlphaBlend(::Color dst, ::Color tint) const { return ::ColorAlphaBlend(dst, *this, tint); }
 
+    /* I think it deprecated
     static Color LightGray() { return LIGHTGRAY; }
     static Color Gray() { return GRAY; }
     static Color DarkGray() { return DARKGRAY; }
@@ -243,6 +240,37 @@ public:
     static Color Blank() { return BLANK; }
     static Color Magenta() { return MAGENTA; }
     static Color RayWhite() { return RAYWHITE; }
+    */
+
+    /**
+     * As an alternative to a function calling convention
+     */
+    constexpr Color LightGray = LIGHTGRAY;
+    constexpr Color Gray = GRAY;
+    constexpr Color DarkGray = DARKGRAY;
+    constexpr Color Yellow = YELLOW;
+    constexpr Color Gold = GOLD;
+    constexpr Color Orange = ORANGE;
+    constexpr Color Pink = PINK;
+    constexpr Color Red = RED;
+    constexpr Color Maroon = MAROON;
+    constexpr Color Green = GREEN;
+    constexpr Color Lime = LIME;
+    constexpr Color DarkGreen = DARKGREEN;
+    constexpr Color SkyBlue = SKYBLUE;
+    constexpr Color Blue = BLUE;
+    constexpr Color DarkBlue = DARKBLUE;
+    constexpr Color Purple = PURPLE;
+    constexpr Color Violet = VIOLET;
+    constexpr Color DarkPurple = DARKPURPLE;
+    constexpr Color Beige = BEIGE;
+    constexpr Color Brown = BROWN;
+    constexpr Color DarkBrown = DARKBROWN;
+    constexpr Color White = WHITE;
+    constexpr Color Black = BLACK;
+    constexpr Color Blank = BLANK;
+    constexpr Color Magenta = MAGENTA;
+    constexpr Color RayWhite = RAYWHITE;
 protected:
     void set(const ::Color& color) {
         r = color.r;

--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -9,6 +9,11 @@
 
 namespace raylib {
 /**
+ * Allows to use the enum through the raylib namespace
+ */
+using ConfigFlags = ::ConfigFlags;
+
+/**
  * Window and Graphics Device Functions.
  */
 class Window {


### PR DESCRIPTION
I was wondering about the implementation of the Colour that are already provided by raylib... why functions?
If there is a reason, I'm sorry, please explain.

But in the mean time I changed them to `constexpr`'s. 