### PR TITLE
fix leak & bytesRead behaviour in FileData

### DIFF
--- a/include/FileData.hpp
+++ b/include/FileData.hpp
@@ -40,6 +40,7 @@ public:
         if (data != nullptr) {
             ::UnloadFileData(data);
             data = nullptr;
+            bytesRead = 0;
         }
     }
 private:

--- a/include/FileData.hpp
+++ b/include/FileData.hpp
@@ -31,7 +31,10 @@ public:
     GETTER(int, BytesRead, bytesRead)
 
     void Load(const std::string& fileName) { Load(fileName.c_str()); }
-    void Load(const char* fileName) { data = ::LoadFileData(fileName, &bytesRead); }
+    void Load(const char* fileName) {
+        Unload();
+        data = ::LoadFileData(fileName, &bytesRead);
+    }
 
     void Unload() {
         if (data != nullptr) {


### PR DESCRIPTION
this makes sure to unload already loaded data before loading new data and reset bytes read when unloading

previously calling `Load` twice or once again after loading via constructor, would leak any already loaded data

previously calling `GetBytesRead` after `Unload`, would return to old length, possibly leading to a nullptr read if only `GetBytesRead` was used to check if `FileData` is empty