### PR TITLE
Change const char** to const char* const* in TextSplit

### DIFF
--- a/include/Functions.hpp
+++ b/include/Functions.hpp
@@ -393,7 +393,7 @@ TextReplace(const std::string& text, const std::string& replace, const std::stri
  */
 [[maybe_unused]] RLCPPAPI std::vector<std::string> TextSplit(const std::string& text, char delimiter) {
     int count;
-    const char** split = ::TextSplit(text.c_str(), delimiter, &count);
+    const char* const* split = ::TextSplit(text.c_str(), delimiter, &count);
     return std::vector<std::string>(split, split + count);
 }
 


### PR DESCRIPTION
Unsure if I missed something, but was running into a `error: cannot initialize a variable of type 'const char **' with an rvalue of type 'char **'` when building with the latest raylib version using various versions of clang on a M1 Mac.

::TextSplit returns a char**, so you can't cast to a const char** implicitly. By specifying const char* const*, we allow implicit conversions from both char** and const char**. The strings are copied into the vector anyway, so adding the extra const specifier changes nothing.