### PR TITLE
add `Window::GetMonitor()` method

### DIFF
--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -349,6 +349,11 @@ public:
      */
     static Vector2 GetPosition() { return ::GetWindowPosition(); }
 
+    /*
+     * Get current window monitor
+     */
+    static int GetMonitor() { return ::GetCurrentMonitor(); }
+
     /**
      * Get window scale DPI factor
      */


### PR DESCRIPTION
This PR only adds the `Window::GetMonitor()` method to retrieve the ID of the monitor where the window is located.  

By the way, I noticed the absence of all monitor-related functions such as `GetMonitorWidth()`, `GetMonitorRefreshRate()`, etc.  

I'm not sure if this is intentional or if it would be acceptable to add them somewhere.