### PR TITLE
Refine default `Camera3D` parameters

### DIFF
--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -25,9 +25,9 @@ public:
      */
     Camera3D(
         ::Vector3 position,
-        ::Vector3 target = ::Vector3{0.0f, 0.0f, 0.0f},
+        ::Vector3 target = ::Vector3{0.0f, 0.0f, -1.0f},
         ::Vector3 up = ::Vector3{0.0f, 1.0f, 0.0f},
-        float fovy = 0,
+        float fovy = 45.0f,
         int projection = CAMERA_PERSPECTIVE)
         : ::Camera3D{position, target, up, fovy, projection} {}
 


### PR DESCRIPTION
I have adjusted the default parameters of `Camera3D` for a more consistent configuration:  
- The default target is now the standard forward `{0,0,-1}` instead of `{0,0,0}`.  
- The fovy is now set to 45° instead of 0, matching the value used in most raylib examples.  
