### PR TITLE
Fix vector3d default init and add tests

### DIFF
--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -22,7 +22,7 @@ public:
     Vector3(float x, float y, float z) : ::Vector3{x, y, z} {}
     Vector3(float x, float y) : ::Vector3{x, y, 0} {}
     Vector3(float x) : ::Vector3{x, 0, 0} {}
-    Vector3() {}
+    Vector3() : ::Vector3{0, 0, 0} {}
 
     Vector3(::Color color) { set(ColorToHSV(color)); }
 

--- a/tests/raylib_cpp_test.cpp
+++ b/tests/raylib_cpp_test.cpp
@@ -38,6 +38,21 @@ int main(int argc, char* argv[]) {
         raylib::Vector2 doublesize = size * 2.0f;
         AssertEqual(size.x, 50);
         AssertEqual(doublesize.x, 100);
+
+        const raylib::Vector2 zero2d;
+        AssertEqual(zero2d.x, 0);
+        AssertEqual(zero2d.y, 0);
+
+        const raylib::Vector3 zero3d;
+        AssertEqual(zero3d.x, 0);
+        AssertEqual(zero3d.y, 0);
+        AssertEqual(zero3d.z, 0);
+
+        const raylib::Vector4 zero4d;
+        AssertEqual(zero4d.x, 0);
+        AssertEqual(zero4d.y, 0);
+        AssertEqual(zero4d.z, 0);
+        AssertEqual(zero4d.w, 0);
     }
 
     // Color


### PR DESCRIPTION
Vector3d did not zero out values on default construct, unlike vector2d and vector4d. Fixed and added tests.