### PR TITLE
added loglevel to window constructor

### DIFF
--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -27,14 +27,15 @@ public:
      * @param height The height of the window.
      * @param title The desired title of the window.
      * @param flags The ConfigFlags to set prior to initializing the window. See SetConfigFlags for more details.
+     * @param logLevel The the current threshold (minimum) log level
      *
      * @see ::SetConfigFlags()
      * @see ConfigFlags
      *
      * @throws raylib::RaylibException Thrown if the window failed to initiate.
      */
-    Window(int width, int height, const std::string& title = "raylib", unsigned int flags = 0) {
-        Init(width, height, title, flags);
+    Window(int width, int height, const std::string& title = "raylib", unsigned int flags = 0, TraceLogLevel logLevel = LOG_ALL) {
+        Init(width, height, title, flags, logLevel);
     }
 
     /**
@@ -55,10 +56,11 @@ public:
      *
      * @throws raylib::RaylibException Thrown if the window failed to initiate.
      */
-    static void Init(int width = 800, int height = 450, const std::string& title = "raylib", unsigned int flags = 0) {
+    static void Init(int width = 800, int height = 450, const std::string& title = "raylib", unsigned int flags = 0, TraceLogLevel logLevel = LOG_ALL) {
         if (flags != 0) {
             ::SetConfigFlags(flags);
         }
+        ::SetTraceLogLevel(logLevel);
         ::InitWindow(width, height, title.c_str());
         if (!::IsWindowReady()) {
             throw RaylibException("Failed to create Window");


### PR DESCRIPTION
It would be nice to set the log level via an optional parameter in the `Window` constructor, as `SetTraceLogLevel()` only works before the window initialization.
Using `Window` as a subclass right now is very annoying, as you cannot call its constructor in the initializer list, because you have to set the log level prior to the construction of `Window`.