### PR TITLE
Method overloads for `Texture::Load`

### DIFF
--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -62,6 +62,31 @@ public:
 
         return *this;
     }
+
+    /**
+    * Unload previous texture, then load texture from image data
+    */
+    void Load(const ::Image& image) {
+        Unload();
+        TextureUnmanaged::Load(image);
+    }
+
+    /**
+    * Unload previous texture, then load cubemap from image.
+    * Multiple image cubemap layouts supported
+    */
+    void Load(const ::Image& image, int layoutType) {
+      Unload();
+      TextureUnmanaged::Load(image, layoutType);
+    }
+
+    /**
+    * Unload previous texture, then load texture from file into GPU memory (VRAM)
+    */
+    void Load(const std::string& fileName) {
+      Unload();
+      TextureUnmanaged::Load(fileName);
+    }
 };
 
 // Create the Texture aliases.


### PR DESCRIPTION
Method overloads have been made for the Texture class to unload the previous texture before loading in a new texture. I'm not sure if other classes (ex: Shader) would have this issue, but it might be worth updating other classes to follow this same behavior for consistency reasons.