### PR TITLE
Fixed Model.hpp to use ModelSkeleton struct [#376]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 cmake-build-debug
 .idea
 docs
+/.vs

--- a/include/Mesh.hpp
+++ b/include/Mesh.hpp
@@ -48,7 +48,7 @@ public:
         other.indices = nullptr;
         other.animVertices = nullptr;
         other.animNormals = nullptr;
-        other.boneIds = nullptr;
+        other.boneIndices = nullptr;
         other.boneWeights = nullptr;
         other.vaoId = 0;
         other.vboId = nullptr;
@@ -73,7 +73,7 @@ public:
         other.indices = nullptr;
         other.animVertices = nullptr;
         other.animNormals = nullptr;
-        other.boneIds = nullptr;
+        other.boneIndices = nullptr;
         other.boneWeights = nullptr;
         other.vaoId = 0;
         other.vboId = nullptr;

--- a/include/MeshUnmanaged.hpp
+++ b/include/MeshUnmanaged.hpp
@@ -35,9 +35,8 @@ public:
         indices = nullptr;
         animVertices = nullptr;
         animNormals = nullptr;
-        boneIds = nullptr;
+        boneIndices = nullptr;
         boneWeights = nullptr;
-        boneMatrices = nullptr;
         boneCount = 0;
         vaoId = 0;
         vboId = nullptr;
@@ -130,7 +129,7 @@ public:
     GETTERSETTER(unsigned short*, Indices, indices) // NOLINT
     GETTERSETTER(float*, AnimVertices, animVertices)
     GETTERSETTER(float*, AnimNormals, animNormals)
-    GETTERSETTER(unsigned char*, BoneIds, boneIds)
+    GETTERSETTER(unsigned char*, BoneIndices, boneIndices)
     GETTERSETTER(float*, BoneWeights, boneWeights)
     GETTERSETTER(unsigned int, VaoId, vaoId)
     GETTERSETTER(unsigned int*, VboId, vboId)
@@ -242,9 +241,8 @@ protected:
         indices = mesh.indices;
         animVertices = mesh.animVertices;
         animNormals = mesh.animNormals;
-        boneIds = mesh.boneIds;
+        boneIndices = mesh.boneIndices;
         boneWeights = mesh.boneWeights;
-        boneMatrices = mesh.boneMatrices;
         vaoId = mesh.vaoId;
         vboId = mesh.vboId;
     }

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -59,13 +59,12 @@ public:
         other.materials = nullptr;
         other.meshMaterial = nullptr;
 
-        /*
-        The Animation Data is now stored within a separate struct called
-        `ModelSkeleton`. The changes below reflect this update.
-        */
         other.skeleton.boneCount = 0;
         other.skeleton.bones = nullptr;
         other.skeleton.bindPose = nullptr;
+
+        ModelAnimPose currentPose;
+        Matrix *boneMatrices;
     }
 
     GETTERSETTER(::Matrix, Transform, transform)
@@ -77,6 +76,8 @@ public:
     GETTERSETTER(int, BoneCount, skeleton.boneCount)
     GETTERSETTER(::BoneInfo*, Bones, skeleton.bones)
     GETTERSETTER(::Transform*, BindPose, skeleton.bindPose)
+    GETTERSETTER(::ModelAnimPose, CurrentPose, currentPose)
+    GETTERSETTER(::Matrix*, BoneMatrices, boneMatrices)
 
     Model& operator=(const ::Model& model) {
         set(model);
@@ -101,6 +102,8 @@ public:
         other.skeleton.boneCount = 0;
         other.skeleton.bones = nullptr;
         other.skeleton.bindPose = nullptr;
+        other.currentPose = nullptr;
+        other.boneMatrices = nullptr;
 
         return *this;
     }
@@ -248,6 +251,8 @@ protected:
         skeleton.boneCount = model.skeleton.boneCount;
         skeleton.bones = model.skeleton.bones;
         skeleton.bindPose = model.skeleton.bindPose;
+        currentPose = model.currentPose;
+        boneMatrices = model.boneMatrices;
     }
 };
 

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -127,7 +127,7 @@ public:
     /**
      * Update model animation pose
      */
-    Model& UpdateAnimation(const ::ModelAnimation& anim, int frame) {
+    Model& UpdateAnimation(const ::ModelAnimation& anim, float frame) {
         ::UpdateModelAnimation(*this, anim, frame);
         return *this;
     }
@@ -135,8 +135,8 @@ public:
     /**
      * Update model animation pose
      */
-    Model& UpdateAnimationBones(const ::ModelAnimation& anim, int frame) {
-        ::UpdateModelAnimationBones(*this, anim, frame);
+    Model& UpdateAnimationsEx(const ::ModelAnimation& animA, float frameA, const ::ModelAnimation& animB, float frameB, float blend) {
+        ::UpdateModelAnimationEx(*this, animA, frameA, animB, frameB, blend);
         return *this;
     }
 

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -58,9 +58,14 @@ public:
         other.meshes = nullptr;
         other.materials = nullptr;
         other.meshMaterial = nullptr;
-        other.boneCount = 0;
-        other.bones = nullptr;
-        other.bindPose = nullptr;
+
+        /*
+        The Animation Data is now stored within a separate struct called
+        `ModelSkeleton`. The changes below reflect this update.
+        */
+        other.skeleton.boneCount = 0;
+        other.skeleton.bones = nullptr;
+        other.skeleton.bindPose = nullptr;
     }
 
     GETTERSETTER(::Matrix, Transform, transform)
@@ -69,9 +74,9 @@ public:
     GETTERSETTER(::Mesh*, Meshes, meshes)
     GETTERSETTER(::Material*, Materials, materials)
     GETTERSETTER(int*, MeshMaterial, meshMaterial)
-    GETTERSETTER(int, BoneCount, boneCount)
-    GETTERSETTER(::BoneInfo*, Bones, bones)
-    GETTERSETTER(::Transform*, BindPose, bindPose)
+    GETTERSETTER(int, BoneCount, skeleton.boneCount)
+    GETTERSETTER(::BoneInfo*, Bones, skeleton.bones)
+    GETTERSETTER(::Transform*, BindPose, skeleton.bindPose)
 
     Model& operator=(const ::Model& model) {
         set(model);
@@ -93,9 +98,9 @@ public:
         other.meshes = nullptr;
         other.materials = nullptr;
         other.meshMaterial = nullptr;
-        other.boneCount = 0;
-        other.bones = nullptr;
-        other.bindPose = nullptr;
+        other.skeleton.boneCount = 0;
+        other.skeleton.bones = nullptr;
+        other.skeleton.bindPose = nullptr;
 
         return *this;
     }
@@ -240,9 +245,9 @@ protected:
         materials = model.materials;
         meshMaterial = model.meshMaterial;
 
-        boneCount = model.boneCount;
-        bones = model.bones;
-        bindPose = model.bindPose;
+        skeleton.boneCount = model.skeleton.boneCount;
+        skeleton.bones = model.skeleton.bones;
+        skeleton.bindPose = model.skeleton.bindPose;
     }
 };
 

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -84,8 +84,8 @@ public:
     /**
      * Update model animation mesh bone matrices (GPU skinning)
      */
-    ModelAnimation& UpdateBones(const ::Model& model, int frame) {
-        ::UpdateModelAnimationBones(model, *this, frame);
+    ModelAnimation& UpdateBones(const ::Model& animA, float frameA, const ::Model& animB, float frameB, float blend) {
+        ::UpdateModelAnimationEx(*this, animA, frameA, animB, frameB, blend);
         return *this;
     }
 

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -26,7 +26,8 @@ public:
         other.keyframePoses = nullptr;
     }
 
-    ~ModelAnimation() { Unload(); }
+    // TODO: Implement a way to unload all animations at once, as the current Unload() only unloads one animation.
+    ~ModelAnimation() { Unload(1); }
 
     /**
      * Load model animations from file
@@ -57,7 +58,7 @@ public:
             return *this;
         }
 
-        Unload();
+        Unload(1);
         set(other);
 
         other.boneCount = 0;
@@ -70,7 +71,7 @@ public:
     /**
      * Unload animation data
      */
-    void Unload() { ::UnloadModelAnimation(*this); }
+    void Unload(int animCount) { ::UnloadModelAnimation(this, animCount); }
 
     /**
      * Update model animation pose

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -22,9 +22,8 @@ public:
         set(other);
 
         other.boneCount = 0;
-        other.frameCount = 0;
-        other.bones = nullptr;
-        other.framePoses = nullptr;
+        other.keyframeCount = 0;
+        other.keyframePoses = nullptr;
     }
 
     ~ModelAnimation() { Unload(); }
@@ -43,9 +42,8 @@ public:
     }
 
     GETTERSETTER(int, BoneCount, boneCount)
-    GETTERSETTER(::BoneInfo*, Bones, bones)
-    GETTERSETTER(int, FrameCount, frameCount)
-    GETTERSETTER(::Transform**, FramePoses, framePoses)
+    GETTERSETTER(int, KeyframeCount, keyframeCount)
+    GETTERSETTER(::Transform**, KeyframePoses, keyframePoses)
 
     ModelAnimation& operator=(const ::ModelAnimation& model) {
         set(model);
@@ -63,9 +61,8 @@ public:
         set(other);
 
         other.boneCount = 0;
-        other.frameCount = 0;
-        other.bones = nullptr;
-        other.framePoses = nullptr;
+        other.keyframeCount = 0;
+        other.keyframePoses = nullptr;
 
         return *this;
     }
@@ -98,9 +95,8 @@ public:
 protected:
     void set(const ::ModelAnimation& model) {
         boneCount = model.boneCount;
-        frameCount = model.frameCount;
-        bones = model.bones;
-        framePoses = model.framePoses;
+        keyframeCount = model.keyframeCount;
+        keyframePoses = model.keyframePoses;
 
         // Duplicate the name. TextCopy() uses the null terminator, which we ignore here.
         for (int i = 0; i < 32; i++) {

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -71,7 +71,7 @@ public:
     /**
      * Unload animation data
      */
-    void Unload(int animCount) { ::UnloadModelAnimation(this, animCount); }
+    void Unload(int animCount) { ::UnloadModelAnimations(this, animCount); }
 
     /**
      * Update model animation pose
@@ -84,8 +84,8 @@ public:
     /**
      * Update model animation mesh bone matrices (GPU skinning)
      */
-    ModelAnimation& UpdateBones(const ::Model& animA, float frameA, const ::Model& animB, float frameB, float blend) {
-        ::UpdateModelAnimationEx(*this, animA, frameA, animB, frameB, blend);
+    ModelAnimation& UpdateBones(const ::Model& model, int frame) {
+        ::UpdateModelAnimation(model, *this, frame);
         return *this;
     }
 


### PR DESCRIPTION
The earlier code references bones, boneCount and bindPose directly, which is no longer possible due to them being stored inside the ModelSkeleton struct. This PR fixes the access to these variables.