### PR TITLE
[Fixes #381] Replaces GPU Skinning for Animation Blending

### DIFF
--- a/include/Matrix.hpp
+++ b/include/Matrix.hpp
@@ -120,8 +120,12 @@ public:
 
     [[nodiscard]] Matrix Multiply(const ::Matrix& right) const { return ::MatrixMultiply(*this, right); }
 
+    [[nodiscard]] Matrix Multiply(float value) const { return ::MatrixMultiplyValue(*this, value); }
+
     Matrix operator*(const ::Matrix& matrix) { return ::MatrixMultiply(*this, matrix); }
 
+    Matrix operator*(float value) { return ::MatrixMultiplyValue(*this, value); }
+    
     static Matrix Frustum(double left, double right, double bottom, double top, double near, double far) {
         return ::MatrixFrustum(left, right, bottom, top, near, far);
     }

--- a/include/Model.hpp
+++ b/include/Model.hpp
@@ -136,9 +136,9 @@ public:
     }
 
     /**
-     * Update model animation pose
+     * Blend two model animation poses
      */
-    Model& UpdateAnimationsEx(const ::ModelAnimation& animA, float frameA, const ::ModelAnimation& animB, float frameB, float blend) {
+    Model& BlendAnimation(const ::ModelAnimation& animA, float frameA, const ::ModelAnimation& animB, float frameB, float blend) {
         ::UpdateModelAnimationEx(*this, animA, frameA, animB, frameB, blend);
         return *this;
     }

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -76,7 +76,7 @@ public:
         ::UnloadModelAnimations(this, 1); 
     }
 
-    static void UnloadAnimations(ModelAnimation *modelAnimation, int count) {
+    static void Unload(ModelAnimation *modelAnimation, int count) {
         ::UnloadModelAnimations(modelAnimation, count); 
     }
 

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -72,7 +72,13 @@ public:
     /**
      * Unload animation data
      */
-    void Unload() { ::UnloadModelAnimations(this, animCount); }
+    void Unload() {
+        if(animCount <= 0) {
+            throw std::runtime_error("ModelAnimation::Unload() called on an object that was not loaded with any animations.");
+        }
+        
+        ::UnloadModelAnimations(this, animCount); 
+    }
 
     /**
      * Update model animation pose

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -76,8 +76,8 @@ public:
         ::UnloadModelAnimations(this, 1); 
     }
 
-    void Unload(int count) {
-        ::UnloadModelAnimations(this, count); 
+    static void UnloadAnimations(ModelAnimation *modelAnimation, int count) {
+        ::UnloadModelAnimations(modelAnimation, count); 
     }
 
     /**

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -76,6 +76,10 @@ public:
         ::UnloadModelAnimations(this, 1); 
     }
 
+    void Unload(int count) {
+        ::UnloadModelAnimations(this, count); 
+    }
+
     /**
      * Update model animation pose
      */

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -13,7 +13,6 @@ namespace raylib {
  * Model animation
  */
 class ModelAnimation : public ::ModelAnimation {
-    int animCount = 0;
 public:
     ModelAnimation(const ::ModelAnimation& model) { set(model); }
 
@@ -34,9 +33,10 @@ public:
      * Load model animations from file
      */
     static std::vector<ModelAnimation> Load(const std::string& fileName) {
-        ::ModelAnimation* modelAnimations = ::LoadModelAnimations(fileName.c_str(), &animCount);
+        int count = 0;
+        ::ModelAnimation* modelAnimations = ::LoadModelAnimations(fileName.c_str(), &count);
 
-        std::vector<ModelAnimation> mats(modelAnimations, modelAnimations + animCount);
+        std::vector<ModelAnimation> mats(modelAnimations, modelAnimations + count);
 
         RL_FREE(modelAnimations);
 
@@ -73,28 +73,25 @@ public:
      * Unload animation data
      */
     void Unload() {
-        if(animCount <= 0) {
-            throw std::runtime_error("ModelAnimation::Unload() called on an object that was not loaded with any animations.");
-        }
-        
-        ::UnloadModelAnimations(this, animCount); 
+        ::UnloadModelAnimations(this, 1); 
     }
 
     /**
      * Update model animation pose
      */
-    ModelAnimation& Update(const ::Model& model, int frame) {
+    ModelAnimation& Update(const ::Model& model, float frame) {
         ::UpdateModelAnimation(model, *this, frame);
         return *this;
     }
 
     /**
-     * Update model animation mesh bone matrices (GPU skinning)
+     * Blend two animation poses
      */
-    ModelAnimation& UpdateBones(const ::Model& model, int frame) {
-        ::UpdateModelAnimation(model, *this, frame);
+    ModelAnimation& Blend(const ::Model& model, float frameA, const ::ModelAnimation& animB, float frameB, float blend) {
+        ::UpdateModelAnimationEx(model, *this, frameA, animB, frameB, blend);
         return *this;
     }
+
 
     /**
      * Check model animation skeleton match

--- a/include/ModelAnimation.hpp
+++ b/include/ModelAnimation.hpp
@@ -13,6 +13,7 @@ namespace raylib {
  * Model animation
  */
 class ModelAnimation : public ::ModelAnimation {
+    int animCount = 0;
 public:
     ModelAnimation(const ::ModelAnimation& model) { set(model); }
 
@@ -26,16 +27,16 @@ public:
         other.keyframePoses = nullptr;
     }
 
-    // TODO: Implement a way to unload all animations at once, as the current Unload() only unloads one animation.
-    ~ModelAnimation() { Unload(1); }
+    // Unloads animation data using populated animCount field, which is set by Load() method.
+    ~ModelAnimation() { Unload(); }
 
     /**
      * Load model animations from file
      */
     static std::vector<ModelAnimation> Load(const std::string& fileName) {
-        int count = 0;
-        ::ModelAnimation* modelAnimations = ::LoadModelAnimations(fileName.c_str(), &count);
-        std::vector<ModelAnimation> mats(modelAnimations, modelAnimations + count);
+        ::ModelAnimation* modelAnimations = ::LoadModelAnimations(fileName.c_str(), &animCount);
+
+        std::vector<ModelAnimation> mats(modelAnimations, modelAnimations + animCount);
 
         RL_FREE(modelAnimations);
 
@@ -58,7 +59,7 @@ public:
             return *this;
         }
 
-        Unload(1);
+        Unload();
         set(other);
 
         other.boneCount = 0;
@@ -71,7 +72,7 @@ public:
     /**
      * Unload animation data
      */
-    void Unload(int animCount) { ::UnloadModelAnimations(this, animCount); }
+    void Unload() { ::UnloadModelAnimations(this, animCount); }
 
     /**
      * Update model animation pose


### PR DESCRIPTION
This series of commits do three things:
- Updates the `Matrix Multiply()` and `Matrix operator*()` to polymorphically use the new `MatrixMultiplyValue()` when passed in a float argument.
- Unload() now unloads one animation by default, unless provided an argument `count`.
- UpdateBones() is replaced with Blend() to reflect new animation mechanism.