### PR TITLE
Reduce constructors using default parameters

### DIFF
--- a/include/Camera2D.hpp
+++ b/include/Camera2D.hpp
@@ -16,8 +16,7 @@ public:
         // Nothing.
     }
 
-    Camera2D() : ::Camera2D() {}
-    Camera2D(::Vector2 offset, ::Vector2 target, float rotation = 0.0f, float zoom = 1.0f)
+    Camera2D(::Vector2 offset = {}, ::Vector2 target = {}, float rotation = 0.0f, float zoom = 1.0f)
         : ::Camera2D{offset, target, rotation, zoom} {}
 
     Camera2D& BeginMode() {

--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -24,14 +24,12 @@ public:
      * @param projection Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
      */
     Camera3D(
-        ::Vector3 position,
+        ::Vector3 position = ::Vector3{0.0f, 0.0f, 0.0f},
         ::Vector3 target = ::Vector3{0.0f, 0.0f, -1.0f},
         ::Vector3 up = ::Vector3{0.0f, 1.0f, 0.0f},
         float fovy = 45.0f,
         int projection = CAMERA_PERSPECTIVE)
         : ::Camera3D{position, target, up, fovy, projection} {}
-
-    Camera3D() {}
 
     GETTERSETTER(::Vector3, Position, position)
     GETTERSETTER(::Vector3, Target, target)

--- a/include/Rectangle.hpp
+++ b/include/Rectangle.hpp
@@ -13,11 +13,7 @@ class Rectangle : public ::Rectangle {
 public:
     constexpr Rectangle(const ::Rectangle& rect) : ::Rectangle{rect.x, rect.y, rect.width, rect.height} {}
 
-    constexpr Rectangle(float x, float y, float width, float height) : ::Rectangle{x, y, width, height} {}
-    constexpr Rectangle(float x, float y, float width) : ::Rectangle{x, y, width, 0} {}
-    constexpr Rectangle(float x, float y) : ::Rectangle{x, y, 0, 0} {}
-    constexpr Rectangle(float x) : ::Rectangle{x, 0, 0, 0} {}
-    constexpr Rectangle() : ::Rectangle{0, 0, 0, 0} {}
+    constexpr Rectangle(float x = 0, float y = 0, float width = 0, float height = 0) : ::Rectangle{x, y, width, height} {}
 
     constexpr Rectangle(::Vector2 position, ::Vector2 size) : ::Rectangle{position.x, position.y, size.x, size.y} {}
     constexpr Rectangle(::Vector2 size) : ::Rectangle{0, 0, size.x, size.y} {}

--- a/include/Vector2.hpp
+++ b/include/Vector2.hpp
@@ -19,9 +19,7 @@ class Vector2 : public ::Vector2 {
 public:
     constexpr Vector2(const ::Vector2& vec) : ::Vector2{vec.x, vec.y} {}
 
-    constexpr Vector2(float x, float y) : ::Vector2{x, y} {}
-    constexpr Vector2(float x) : ::Vector2{x, 0} {}
-    constexpr Vector2() : ::Vector2{0, 0} {}
+    constexpr Vector2(float x = 0, float y = 0) : ::Vector2{x, y} {}
 
     GETTERSETTER(float, X, x)
     GETTERSETTER(float, Y, y)

--- a/include/Vector3.hpp
+++ b/include/Vector3.hpp
@@ -19,10 +19,7 @@ class Vector3 : public ::Vector3 {
 public:
     constexpr Vector3(const ::Vector3& vec) : ::Vector3{vec.x, vec.y, vec.z} {}
 
-    constexpr Vector3(float x, float y, float z) : ::Vector3{x, y, z} {}
-    constexpr Vector3(float x, float y) : ::Vector3{x, y, 0} {}
-    constexpr Vector3(float x) : ::Vector3{x, 0, 0} {}
-    constexpr Vector3() : ::Vector3{0, 0, 0} {}
+    constexpr Vector3(float x = 0, float y = 0, float z = 0) : ::Vector3{x, y, z} {}
 
     Vector3(::Color color) { set(ColorToHSV(color)); }
 

--- a/include/Vector4.hpp
+++ b/include/Vector4.hpp
@@ -20,11 +20,7 @@ class Vector4 : public ::Vector4 {
 public:
     constexpr Vector4(const ::Vector4& vec) : ::Vector4{vec.x, vec.y, vec.z, vec.w} {}
 
-    constexpr Vector4(float x, float y, float z, float w) : ::Vector4{x, y, z, w} {}
-    constexpr Vector4(float x, float y, float z) : ::Vector4{x, y, z, 0} {}
-    constexpr Vector4(float x, float y) : ::Vector4{x, y, 0, 0} {}
-    constexpr Vector4(float x) : ::Vector4{x, 0, 0, 0} {}
-    constexpr Vector4() : ::Vector4{0, 0, 0, 0} {}
+    constexpr Vector4(float x = 0, float y = 0, float z = 0, float w = 0) : ::Vector4{x, y, z, w} {}
     constexpr Vector4(::Rectangle rectangle) : ::Vector4{rectangle.x, rectangle.y, rectangle.width, rectangle.height} {}
 
     Vector4(::Color color) { set(ColorNormalize(color)); }


### PR DESCRIPTION
Merges redundant constructors into single constructors with default parameters across Vector2, Vector3, Vector4, Rectangle, Camera2D, and Camera3D.

- `Vector2`: 3 float constructors → 1 (`x=0, y=0`)
- `Vector3`: 4 float constructors → 1 (`x=0, y=0, z=0`)
- `Vector4`: 5 float constructors → 1 (`x=0, y=0, z=0, w=0`)
- `Rectangle`: 5 float constructors → 1 (`x=0, y=0, width=0, height=0`)
- `Camera2D`: default + parameterized → 1 (`offset={}, target={}, rotation=0, zoom=1`)
- `Camera3D`: default + parameterized → 1 (`position={0,0,0}` + existing defaults)