### PR TITLE
Fix C++20 modules build failure

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -20,6 +20,7 @@ configure_cpp_module_target(raylib_cpp_modules)
 target_link_libraries(raylib_cpp_modules
   PUBLIC
     raylib_cpp
+    raylib
 )
 
 target_include_directories(raylib_cpp_modules


### PR DESCRIPTION
**Justification**:
When trying to build with C++20 modules (by setting BUILD_RAYLIB_CPP_MODULES option in CMakeLists.txt), build fails with error:
```
fatal error C1083: Cannot open include file: 'raylib.h': No such file or directory
```

**Change**:
Make `raylib_cpp_modules` target also link `raylib` as library.

Fixes #397 