### PR TITLE
Changing the default zoom value Camera3D.

### DIFF
--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -85,7 +85,7 @@ public:
     /**
      * Update camera movement/rotation
      */
-    Camera3D& Update(::Vector3 movement, ::Vector3 rotation, float zoom = 1.0f) {
+    Camera3D& Update(::Vector3 movement, ::Vector3 rotation, float zoom = 0.0f) {
         ::UpdateCameraPro(this, movement, rotation, zoom);
         return *this;
     }


### PR DESCRIPTION
A zoom value of 1.0f is confusing during development