### PR TITLE
Modified GetMouseRay to GetScreenToWorldRay (raylib 5.5 update)

### DIFF
--- a/include/Camera2D.hpp
+++ b/include/Camera2D.hpp
@@ -4,6 +4,7 @@
 #include "./Vector2.hpp"
 #include "./raylib-cpp-utils.hpp"
 #include "./raylib.hpp"
+#include <raylib.h>
 
 namespace raylib {
 /**

--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -93,7 +93,7 @@ public:
     /**
      * Returns a ray trace from mouse position
      */
-    Ray GetMouseRay(::Vector2 mousePosition) const { return ::GetMouseRay(mousePosition, *this); }
+    Ray GetMouseRay(::Vector2 mousePosition) const { return ::GetScreenToWorldRay(mousePosition, *this); }
 
     /**
      * Returns the screen space position for a 3d world space position

--- a/include/Camera3D.hpp
+++ b/include/Camera3D.hpp
@@ -93,7 +93,7 @@ public:
     /**
      * Returns a ray trace from mouse position
      */
-    Ray GetMouseRay(::Vector2 mousePosition) const { return ::GetScreenToWorldRay(mousePosition, *this); }
+    Ray GetScreenToWorldRay(::Vector2 mousePosition) const { return ::GetScreenToWorldRay(mousePosition, *this); }
 
     /**
      * Returns the screen space position for a 3d world space position

--- a/include/Mouse.hpp
+++ b/include/Mouse.hpp
@@ -4,6 +4,7 @@
 #include "./Functions.hpp"
 #include "./Vector2.hpp"
 #include "./raylib.hpp"
+#include <raylib.h>
 
 namespace raylib {
 /**
@@ -136,14 +137,14 @@ RLCPP_MAYBEUNUSED RLCPPAPI inline Vector2 GetTouchPosition(int index) {
  * Get a ray trace from mouse position
  */
 RLCPP_MAYBEUNUSED RLCPPAPI inline Ray GetRay(::Vector2 mousePosition, const ::Camera& camera) {
-    return ::GetMouseRay(mousePosition, camera);
+    return ::GetScreenToWorldRay(mousePosition, camera);
 }
 
 /**
  * Get a ray trace from mouse position
  */
 RLCPP_MAYBEUNUSED RLCPPAPI inline Ray GetRay(const ::Camera& camera) {
-    return ::GetMouseRay(::GetMousePosition(), camera);
+    return ::GetScreenToWorldRay(::GetMousePosition(), camera);
 }
 } // namespace Mouse
 } // namespace raylib

--- a/include/Mouse.hpp
+++ b/include/Mouse.hpp
@@ -136,14 +136,14 @@ RLCPP_MAYBEUNUSED RLCPPAPI inline Vector2 GetTouchPosition(int index) {
 /**
  * Get a ray trace from mouse position
  */
-RLCPP_MAYBEUNUSED RLCPPAPI inline Ray GetRay(::Vector2 mousePosition, const ::Camera& camera) {
+RLCPP_MAYBEUNUSED RLCPPAPI inline Ray GetScreenToWorldRay(::Vector2 mousePosition, const ::Camera& camera) {
     return ::GetScreenToWorldRay(mousePosition, camera);
 }
 
 /**
  * Get a ray trace from mouse position
  */
-RLCPP_MAYBEUNUSED RLCPPAPI inline Ray GetRay(const ::Camera& camera) {
+RLCPP_MAYBEUNUSED RLCPPAPI inline Ray GetScreenToWorldRay(const ::Camera& camera) {
     return ::GetScreenToWorldRay(::GetMousePosition(), camera);
 }
 } // namespace Mouse

--- a/include/Ray.hpp
+++ b/include/Ray.hpp
@@ -69,14 +69,14 @@ public:
     /**
      * Get a ray trace from mouse position
      */
-    static Ray GetMouse(::Vector2 mousePosition, const ::Camera& camera) {
+    static Ray GetScreenToWorldRay(::Vector2 mousePosition, const ::Camera& camera) {
         return ::GetScreenToWorldRay(mousePosition, camera);
     }
 
     /**
      * Get a ray trace from mouse position
      */
-    static Ray GetMouse(const ::Camera& camera) { return ::GetScreenToWorldRay(::GetMousePosition(), camera); }
+    static Ray GetScreenToWorldRay(const ::Camera& camera) { return ::GetScreenToWorldRay(::GetMousePosition(), camera); }
 protected:
     void set(const ::Ray& ray) {
         position = ray.position;

--- a/include/Ray.hpp
+++ b/include/Ray.hpp
@@ -18,7 +18,7 @@ public:
         // Nothing.
     }
 
-    Ray(::Vector2 mousePosition, const ::Camera& camera) { set(::GetMouseRay(mousePosition, camera)); }
+    Ray(::Vector2 mousePosition, const ::Camera& camera) { set(::GetScreenToWorldRay(mousePosition, camera)); }
 
     Ray& operator=(const ::Ray& ray) {
         set(ray);
@@ -70,13 +70,13 @@ public:
      * Get a ray trace from mouse position
      */
     static Ray GetMouse(::Vector2 mousePosition, const ::Camera& camera) {
-        return ::GetMouseRay(mousePosition, camera);
+        return ::GetScreenToWorldRay(mousePosition, camera);
     }
 
     /**
      * Get a ray trace from mouse position
      */
-    static Ray GetMouse(const ::Camera& camera) { return ::GetMouseRay(::GetMousePosition(), camera); }
+    static Ray GetMouse(const ::Camera& camera) { return ::GetScreenToWorldRay(::GetMousePosition(), camera); }
 protected:
     void set(const ::Ray& ray) {
         position = ray.position;


### PR DESCRIPTION
GetMouseRay is deprecated so i updated it to GetScreenToWorldRay. [Removed mentioned here](https://github.com/raysan5/raylib/pull/3830)