### PR TITLE
Fix compatibility between raylib 6.0 and 6.1

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,8 +15,8 @@ if (NOT raylib_FOUND)
         FetchContent_Declare(
         raylib
         GIT_REPOSITORY https://github.com/raysan5/raylib.git
-        # 6.5
-        GIT_TAG f00317bead662c6e7fd5dfc92f16ca37f8a2e08f
+        # Track raylib's master branch, so CI verifies compatibility with the latest raylib.
+        GIT_TAG master
         GIT_SHALLOW 1
     )
     FetchContent_GetProperties(raylib)

--- a/include/Image.hpp
+++ b/include/Image.hpp
@@ -653,8 +653,13 @@ public:
 
     // TODO: Add ImageDrawTriangle()
 
-    void Draw(const ::Image& src, ::Rectangle srcRec, ::Vector2 position, ::Color tint = {255, 255, 255, 255}) {
-        ::ImageDrawImageRec(this, src, srcRec,position , tint);
+    void Draw(const ::Image& src, ::Rectangle srcRec, ::Rectangle dstRec, ::Color tint = {255, 255, 255, 255}) {
+        // raylib 6.1 replaces ImageDraw() with ImageDrawImagePro().
+#if RAYLIB_VERSION_MAJOR == 6 && RAYLIB_VERSION_MINOR == 0
+        ::ImageDraw(this, src, srcRec, dstRec, tint);
+#else
+        ::ImageDrawImagePro(this, src, srcRec, dstRec, {0, 0}, 0, tint);
+#endif
     }
 
     void DrawText(const char* text, ::Vector2 position, int fontSize, ::Color color = {255, 255, 255, 255}) {

--- a/tests/raylib_cpp_test.cpp
+++ b/tests/raylib_cpp_test.cpp
@@ -103,7 +103,12 @@ int main(int argc, char* argv[]) {
     {
         std::string input = "Hello World!";
         std::string output = raylib::TextInsert(input, "Good!", 0);
+        // raylib 6.1 fixes a TextInsert() bug that dropped the text before the insert position.
+#if RAYLIB_VERSION_MAJOR == 6 && RAYLIB_VERSION_MINOR == 0
         AssertEqual(output, "Good! World!");
+#else
+        AssertEqual(output, "Good!Hello World!");
+#endif
     }
 
     // raylib::TextSubtext()


### PR DESCRIPTION
Image::Draw() used ImageDrawImageRec unconditionally, which does not exist in raylib 6.0. Guard by raylib version and use ImageDrawImagePro on 6.1+.